### PR TITLE
Get ready for new Atmosphere release

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Remember to restart Switch
 | World of Goo | all | 32-bit game, not supported |
 | YouTube | plugins | Unknown |
 
-Titles other than 32-bit are added to exceptions.txt which is treated as Black list, you can find it in root of repo. SaltyNX reads it from SaltySD folder. `X` at the beginning of titleid means that this game will not load any patches and plugins.
+Titles other than 32-bit are added to exceptions.txt which is treated as Black list, you can find it in root of repo. SaltyNX reads it from SaltySD folder. `X` at the beginning of titleid means that this game will not load any patches and plugins. `R` at the beginning of titleid means that this game will not load any patches and plugins if romfs mod for this game is installed.
 
 32-bit games are ignored by default for patches and plugins.

--- a/libnx_min/nx/source/services/applet.c
+++ b/libnx_min/nx/source/services/applet.c
@@ -2503,7 +2503,7 @@ bool appletHolderCheckFinished(AppletHolder *h) {
     return R_SUCCEEDED(eventWait(&h->StateChangedEvent, 0));
 }
 
-u32 appletHolderGetExitReason(AppletHolder *h) {
+LibAppletExitReason appletHolderGetExitReason(AppletHolder *h) {
     return h->exitreason;
 }
 

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -20,7 +20,7 @@ u32 __nx_applet_type = AppletType_None;
 void serviceThread(void* buf);
 
 Handle saltyport, sdcard, injectserv;
-static char g_heap[0xB0000];
+static char g_heap[0x80000];
 bool should_terminate = false;
 bool already_hijacking = false;
 DebugEventInfo eventinfo;

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -51,15 +51,16 @@ void __appExit(void)
 	smExit();
 }
 
+u64 TIDnow;
 u64 PIDnow;
 
-void renameCheatsFolder(bool Undo) {
+void renameCheatsFolder() {
 	char* cheatspath = (char*)malloc(0x40);
 	char* cheatspathtemp = (char*)malloc(0x40);
 
-	snprintf(cheatspath, 0x40, "sdmc:/atmosphere/contents/%016lx/cheats", eventinfo.tid);
+	snprintf(cheatspath, 0x40, "sdmc:/atmosphere/contents/%016lx/cheats", TIDnow);
 	snprintf(cheatspathtemp, 0x40, "%stemp", cheatspath);
-	if (!Undo) {
+	if (!check) {
 		rename(cheatspath, cheatspathtemp);
 		check = true;
 	}
@@ -171,10 +172,13 @@ void hijack_pid(u64 pid)
 	while (1)
 	{
 		ret = svcGetDebugEventInfo(&eventinfo, debug);
+
 		if (check == false) {
+			TIDnow = eventinfo.tid;
 			exception = 0;
-			renameCheatsFolder(false);
+			renameCheatsFolder();
 		}
+
 		if (ret)
 		{
 			SaltySD_printf("SaltySD: svcGetDebugEventInfo returned %x, breaking\n", ret);
@@ -278,7 +282,7 @@ void hijack_pid(u64 pid)
 		svcSleepThread(-1);
 	}
 	while (!threads);
-	renameCheatsFolder(true);
+	renameCheatsFolder();
 	
 	hijack_bootstrap(&debug, pid, tids[0]);
 	
@@ -288,7 +292,7 @@ void hijack_pid(u64 pid)
 abort_bootstrap:
 	disable = 0;
 	free(tids);
-	renameCheatsFolder(true);
+	renameCheatsFolder();
 				
 	already_hijacking = false;
 	svcCloseHandle(debug);

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -61,11 +61,14 @@ void renameCheatsFolder(bool Undo) {
 	snprintf(cheatspathtemp, 0x40, "%stemp", cheatspath);
 	if (!Undo) {
 		rename(cheatspath, cheatspathtemp);
+		check = true;
 	}
-	else rename(cheatspathtemp, cheatspath);
+	else {
+		rename(cheatspathtemp, cheatspath);
+		check = false;
+	}
 	free(cheatspath);
 	free(cheatspathtemp);
-	check = true;
 	return;
 }
 

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -77,8 +77,9 @@ bool isModInstalled() {
 
 	DIR* dir = opendir(romfspath);
 	if (dir) {
+		if (readdir(dir) != NULL)
+			flag = true;
 		closedir(dir);
-		flag = true;
 	}
 
 	free(romfspath);

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -77,7 +77,7 @@ bool isModInstalled() {
 
 	DIR* dir = opendir(romfspath);
 	if (dir) {
-		if (readdir(dir) != NULL)
+		if (readdir(dir))
 			flag = true;
 		closedir(dir);
 	}

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -234,14 +234,17 @@ void hijack_pid(u64 pid)
 						fclose(except);
 						goto abort_bootstrap;
 					}
-					else if (!strncasecmp(exceptions, titleidnumR, 17) && isModInstalled()) {
-						SaltySD_printf("SaltySD: TID %016lx has romfs mod folder, aborting bootstrap...\n", eventinfo.tid);
-						if (!shmemMap(&_sharedMemory)) {
-							memset(shmemGetAddr(&_sharedMemory), 0, 0x1000);
-							shmemUnmap(&_sharedMemory);
+					else if (!strncasecmp(exceptions, titleidnumR, 17)) {
+						if (isModInstalled()) {
+							SaltySD_printf("SaltySD: TID %016lx is in exceptions.txt as romfs excluded, aborting bootstrap...\n", eventinfo.tid);
+							if (!shmemMap(&_sharedMemory)) {
+								memset(shmemGetAddr(&_sharedMemory), 0, 0x1000);
+								shmemUnmap(&_sharedMemory);
+							}
+							fclose(except);
+							goto abort_bootstrap;
 						}
-						fclose(except);
-						goto abort_bootstrap;
+						else SaltySD_printf("SaltySD: TID %016lx is in exceptions.txt as romfs excluded, but no romfs mod was detected...\n", eventinfo.tid);
 					}
 					else if (!strncasecmp(exceptions, titleidnum, 16)) {
 						SaltySD_printf("SaltySD: TID %016lx is in exceptions.txt, aborting loading plugins...\n", eventinfo.tid);


### PR DESCRIPTION
Atmosphere will introduce new LayeredFS system for games. It will steal from Application pool memory for games listed in source code of Atmosphere. This way it wants to handle games with big number of romfs files. This can affect SaltyNX loading because it relies also on stealing from Application some memory, but Atmosphere will have a priority. 

So to combat games that will have issues after introducing this new feature exceptions.txt will accept now new flag:

```
R0100000000010000
```

titleid of game preceded by "R" will abort injecting SaltyNX if any file or folder will be detected inside `atmosphere/contents/*titleid*/romfs/`. 

Waiting for new Atmosphere release to check how this works and update exceptions.txt with new games if necessary.

And thanks to new devkit release memory footprint of SaltyNX sysmodule will be reduced by almost 50%.