### PR TITLE
Integrate NX-FPS and ReverseNX-RT into Core, support patching NROs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Remember to restart Switch
 | CelDamage HD | all | 32-bit game, not supported |
 | DEADLY PREMONITION Origins | all | 32-bit game, not supported |
 | Dies irae Amantes amentes For Nintendo Switch | all | 32-bit game, not supported |
+| EA SPORTS FC 24 | plugins | heap related |
 | Goat Simulator | all | 32-bit game, not supported |
 | Grandia Collection | all | Only launcher is 64-bit, games are 32-bit |
 | Grid: Autosport | plugins | Heap related |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Background process for the Nintendo Switch for file/code modification
 
 Created by: https://github.com/shinyquagsire23
 
-This fork includes many QoL improvements and beside plugins support also supports patches.
+This fork includes many QoL improvements and beside plugins support also supports patches. 
+
+Since 0.7.0 version NX-FPS and ReverseNX-RT is an intergral part of SaltyNX Core. This allows us to run them in 64-bit games not compatible with plugins.
 
 ![GitHub all releases](https://img.shields.io/github/downloads/masagrator/SaltyNX/total?style=for-the-badge)
 ---
@@ -18,7 +20,7 @@ For additional functions you need SaltyNX-Tool
 
 https://github.com/masagrator/SaltyNX-Tool
 
-Tests were done on FW 7.0.1-16.0.0 with Atmosphere up to 1.5.0
+Tests were done on FW 7.0.1-16.1.0 with Atmosphere up to 1.5.5
 
 No technical support for:
 - Atmosphere forks

--- a/exceptions.txt
+++ b/exceptions.txt
@@ -6,10 +6,6 @@
 ;1.0.0-1.4.0 crash
 0100DCA0064A6000
 
-;Tesla Menu
-;Just in case (old titleid, new one is blacklisted by internal titleid validating)
-X010000000007E51A
-
 ;YouTube
 ;Stucks in infinite loop
 X01003A400C3DA000
@@ -46,3 +42,7 @@ X0100964012528000
 ;Plants vs. Zombies: Battle for Neighborville
 ;1.0.3 crash on boot
 0100C56010FD8000
+
+;EA SPORTS FC 24
+;1.0.0 - v1.53.dd6d crash
+0100BDB01A0E6000

--- a/saltysd_core/source/NX-FPS.cpp
+++ b/saltysd_core/source/NX-FPS.cpp
@@ -15,6 +15,7 @@ extern "C" {
 	typedef u32 (*_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR_0)(void* VkQueue_T, void* VkPresentInfoKHR);
 	typedef u64 (*_ZN2nn2os17ConvertToTimeSpanENS0_4TickE_0)(u64 tick);
 	typedef u64 (*_ZN2nn2os13GetSystemTickEv_0)();
+	typedef void (*_ZN3nvn15nvnLoadCPPProcsEPNS_6DeviceEPFPFvvEPKS0_PKcE)(void* nvnDevice, void* GetProcAddress);
 }
 
 struct {
@@ -25,6 +26,7 @@ struct {
 	uintptr_t nvSwapchainQueuePresentKHR;
 	uintptr_t ConvertToTimeSpan;
 	uintptr_t GetSystemTick;
+	uintptr_t nvnLoadCPPProcs;
 } Address_weaks;
 
 SharedMemory _sharedmemory = {};
@@ -633,8 +635,8 @@ void* nvnAcquireTexture(void* nvnWindow, void* nvnSync, void* index) {
 	return ret;
 }
 
-uintptr_t nvnGetProcAddress (void* unk1, const char* nvnFunction) {
-	uintptr_t address = ((GetProcAddress)(Ptrs.nvnDeviceGetProcAddress))(unk1, nvnFunction);
+uintptr_t nvnGetProcAddress (void* nvnDevice, const char* nvnFunction) {
+	uintptr_t address = ((GetProcAddress)(Ptrs.nvnDeviceGetProcAddress))(nvnDevice, nvnFunction);
 	if (!strcmp("nvnDeviceGetProcAddress", nvnFunction))
 		return Address.nvnGetProcAddress;
 	else if (!strcmp("nvnQueuePresentTexture", nvnFunction)) {
@@ -666,6 +668,14 @@ uintptr_t nvnGetProcAddress (void* unk1, const char* nvnFunction) {
 		return Address.nvnSyncWait;
 	}
 	else return address;
+}
+
+void nvnLoadCPPProcs(void* nvnDevice, void* GetProcAddress) {
+	if (GetProcAddress) {
+		Ptrs.nvnDeviceGetProcAddress = (uintptr_t)&nvnGetProcAddress;
+		GetProcAddress = (void*)&nvnGetProcAddress;
+	}
+	return ((_ZN3nvn15nvnLoadCPPProcsEPNS_6DeviceEPFPFvvEPKS0_PKcE)(Address_weaks.nvnLoadCPPProcs))(nvnDevice, GetProcAddress);
 }
 
 uintptr_t nvnBootstrapLoader_1(const char* nvnName) {
@@ -709,11 +719,13 @@ extern "C" {
 				Address_weaks.nvSwapchainQueuePresentKHR = SaltySDCore_FindSymbolBuiltin("_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR");
 				Address_weaks.ConvertToTimeSpan = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os17ConvertToTimeSpanENS0_4TickE");
 				Address_weaks.GetSystemTick = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os13GetSystemTickEv");
+				Address_weaks.nvnLoadCPPProcs = SaltySDCore_FindSymbolBuiltin("_ZN3nvn15nvnLoadCPPProcsEPNS_6DeviceEPFPFvvEPKS0_PKcE");
 				SaltySDCore_ReplaceImport("nvnBootstrapLoader", (void*)nvnBootstrapLoader_1);
 				SaltySDCore_ReplaceImport("eglSwapBuffers", (void*)eglSwap);
 				SaltySDCore_ReplaceImport("eglSwapInterval", (void*)eglInterval);
 				SaltySDCore_ReplaceImport("vkQueuePresentKHR", (void*)vulkanSwap);
 				SaltySDCore_ReplaceImport("_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR", (void*)vulkanSwap2);
+				SaltySDCore_ReplaceImport("_ZN3nvn15nvnLoadCPPProcsEPNS_6DeviceEPFPFvvEPKS0_PKcE", (void*)nvnLoadCPPProcs);
 
 				Shared.FPSlocked = (uint8_t*)(base + 10);
 				Shared.FPSmode = (uint8_t*)(base + 11);

--- a/saltysd_core/source/NX-FPS.cpp
+++ b/saltysd_core/source/NX-FPS.cpp
@@ -1,0 +1,779 @@
+#include <switch_min.h>
+#include "saltysd_ipc.h"
+#include "saltysd_dynamic.h"
+#include "saltysd_core.h"
+#include "ltoa.h"
+#include <cstdlib>
+#include <cmath>
+#include "lock.hpp"
+
+extern "C" {
+	typedef u64 (*nvnBootstrapLoader_0)(const char * nvnName);
+	typedef int (*eglSwapBuffers_0)(void* EGLDisplay, void* EGLSurface);
+	typedef int (*eglSwapInterval_0)(void* EGLDisplay, int interval);
+	typedef u32 (*vkQueuePresentKHR_0)(void* vkQueue, void* VkPresentInfoKHR);
+	typedef u32 (*_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR_0)(void* VkQueue_T, void* VkPresentInfoKHR);
+	typedef u64 (*_ZN2nn2os17ConvertToTimeSpanENS0_4TickE_0)(u64 tick);
+	typedef u64 (*_ZN2nn2os13GetSystemTickEv_0)();
+}
+
+struct {
+	uintptr_t nvnBootstrapLoader;
+	uintptr_t eglSwapBuffers;
+	uintptr_t eglSwapInterval;
+	uintptr_t vkQueuePresentKHR;
+	uintptr_t nvSwapchainQueuePresentKHR;
+	uintptr_t ConvertToTimeSpan;
+	uintptr_t GetSystemTick;
+} Address_weaks;
+
+SharedMemory _sharedmemory = {};
+Handle remoteSharedMemory = 0;
+ptrdiff_t SharedMemoryOffset = 1234;
+uint8_t* configBuffer = 0;
+size_t configSize = 0;
+Result configRC = 1;
+
+Result readConfig(const char* path, uint8_t** output_buffer) {
+	FILE* patch_file = SaltySDCore_fopen(path, "rb");
+	SaltySDCore_fseek(patch_file, 0, 2);
+	configSize = SaltySDCore_ftell(patch_file);
+	SaltySDCore_fseek(patch_file, 0, 0);
+	uint8_t* buffer = (uint8_t*)calloc(1, 0x34);
+	SaltySDCore_fread(buffer, 0x34, 1, patch_file);
+	if (SaltySDCore_ftell(patch_file) != 0x34 || !LOCK::isValid(buffer, 0x34)) {
+		SaltySDCore_fclose(patch_file);
+		free(buffer);
+		return 1;
+	}
+	if (LOCK::gen == 2) {
+		Result ret = LOCK::applyMasterWrite(patch_file, configSize);
+		if (R_FAILED(ret))  {
+			SaltySDCore_fclose(patch_file);
+			return ret;
+		}
+		configSize = *(uint32_t*)(&(buffer[0x30]));
+	}
+	free(buffer);
+	buffer = (uint8_t*)calloc(1, configSize);
+	SaltySDCore_fseek(patch_file, 0, 0);
+	SaltySDCore_fread(buffer, configSize, 1, patch_file);
+	SaltySDCore_fclose(patch_file);
+	*output_buffer = buffer;
+	return 0;
+}
+
+struct {
+	uint8_t* FPS = 0;
+	float* FPSavg = 0;
+	bool* pluginActive = 0;
+	uint8_t* FPSlocked = 0;
+	uint8_t* FPSmode = 0;
+	uint8_t* ZeroSync = 0;
+	uint8_t* patchApplied = 0;
+	uint8_t* API = 0;
+	uint32_t* FPSticks = 0;
+	uint8_t* Buffers = 0;
+	uint8_t* SetBuffers = 0;
+	uint8_t* ActiveBuffers = 0;
+	uint8_t* SetActiveBuffers = 0;
+} Shared;
+
+struct {
+	uintptr_t nvnDeviceGetProcAddress;
+	uintptr_t nvnQueuePresentTexture;
+
+	uintptr_t nvnWindowSetPresentInterval;
+	uintptr_t nvnWindowGetPresentInterval;
+	uintptr_t nvnWindowBuilderSetTextures;
+	uintptr_t nvnWindowAcquireTexture;
+	uintptr_t nvnSyncWait;
+
+	uintptr_t nvnWindowSetNumActiveTextures;
+} Ptrs;
+
+struct {
+	uintptr_t nvnWindowGetProcAddress;
+	uintptr_t nvnQueuePresentTexture;
+	uintptr_t nvnWindowSetPresentInterval;
+	uintptr_t nvnWindowBuilderSetTextures;
+	uintptr_t nvnWindowAcquireTexture;
+	uintptr_t nvnSyncWait;
+	uintptr_t nvnGetProcAddress;
+	uintptr_t nvnWindowSetNumActiveTextures;
+} Address;
+
+struct {
+	uint8_t FPS = 0xFF;
+	float FPSavg = 255;
+	bool FPSmode = 0;
+} Stats;
+
+static uint32_t systemtickfrequency = 19200000;
+typedef void (*nvnQueuePresentTexture_0)(void* _this, void* unk2_1, void* unk3_1);
+typedef uintptr_t (*GetProcAddress)(void* unk1_a, const char * nvnFunction_a);
+
+bool changeFPS = false;
+bool changedFPS = false;
+typedef void (*nvnBuilderSetTextures_0)(void* nvnWindowBuilder, int buffers, void* texturesBuffer);
+typedef void (*nvnWindowSetNumActiveTextures_0)(void* nvnWindow, int buffers);
+typedef void* (*nvnWindowAcquireTexture_0)(void* nvnWindow, void* nvnSync, void* index);
+typedef void (*nvnSetPresentInterval_0)(void* nvnWindow, int mode);
+typedef int (*nvnGetPresentInterval_0)(void* nvnWindow);
+typedef void* (*nvnSyncWait_0)(void* _this, uint64_t timeout_ns);
+void* WindowSync = 0;
+uint64_t startFrameTick = 0;
+
+enum {
+	ZeroSyncType_None,
+	ZeroSyncType_Soft,
+	ZeroSyncType_Semi
+};
+
+inline void createBuildidPath(uint64_t buildid, char* titleid, char* buffer) {
+	strcpy(buffer, "sdmc:/SaltySD/plugins/FPSLocker/patches/0");
+	strcat(buffer, &titleid[0]);
+	strcat(buffer, "/");
+	ltoa(buildid, &titleid[0], 16);
+	int zero_count = 16 - strlen(&titleid[0]);
+	for (int i = 0; i < zero_count; i++) {
+		strcat(buffer, "0");
+	}
+	strcat(buffer, &titleid[0]);
+	strcat(buffer, ".bin");	
+}
+
+inline void CheckTitleID(char* buffer) {
+    uint64_t titid = 0;
+    svcGetInfo(&titid, 18, CUR_PROCESS_HANDLE, 0);	
+    ltoa(titid, buffer, 16);
+}
+
+inline uint64_t getMainAddress() {
+	MemoryInfo memoryinfo = {0};
+	u32 pageinfo = 0;
+
+	uint64_t base_address = SaltySDCore_getCodeStart() + 0x4000;
+	for (size_t i = 0; i < 3; i++) {
+		Result rc = svcQueryMemory(&memoryinfo, &pageinfo, base_address);
+		if (R_FAILED(rc)) return 0;
+		if ((memoryinfo.addr == base_address) && (memoryinfo.perm & Perm_X))
+			return base_address;
+		base_address = memoryinfo.addr+memoryinfo.size;
+	}
+
+	return 0;
+}
+
+uint32_t vulkanSwap2 (void* VkQueue_T, void* VkPresentInfoKHR) {
+	static uint8_t FPS_temp = 0;
+	static uint64_t starttick = 0;
+	static uint64_t endtick = 0;
+	static uint64_t deltatick = 0;
+	static uint64_t frameend = 0;
+	static uint64_t framedelta = 0;
+	static uint64_t frameavg = 0;
+	static uint8_t FPSlock = 0;
+	static uint32_t FPStiming = 0;
+	static uint8_t FPStickItr = 0;
+	static uint8_t range = 0;
+	
+	bool FPSlock_delayed = false;
+	
+	if (!starttick) {
+		*(Shared.API) = 3;
+		starttick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	}
+	if (FPStiming && !LOCK::blockDelayFPS) {
+		if ((((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))() - frameend) < FPStiming) {
+			FPSlock_delayed = true;
+		}
+		while ((((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))() - frameend) < FPStiming) {
+			svcSleepThread(-2);
+		}
+	}
+
+	uint32_t vulkanResult = ((_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR_0)(Address_weaks.nvSwapchainQueuePresentKHR))(VkQueue_T, VkPresentInfoKHR);
+	endtick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	framedelta = endtick - frameend;
+	frameavg = ((9*frameavg) + framedelta) / 10;
+	Stats.FPSavg = systemtickfrequency / (float)frameavg;
+
+	if (FPSlock_delayed && FPStiming) {
+		if (Stats.FPSavg > ((float)FPSlock)) {
+			if (range < 200) {
+				FPStiming += 20;
+				range++;
+			}
+		}
+		else if ((std::lround(Stats.FPSavg) == FPSlock) && (Stats.FPSavg < (float)FPSlock)) {
+			if (range > 0) {
+				FPStiming -= 20;
+				range--;
+			}
+		}
+	}
+
+	frameend = endtick;
+	
+	FPS_temp++;
+	deltatick = endtick - starttick;
+
+	Shared.FPSticks[FPStickItr++] = framedelta;
+	FPStickItr %= 10;
+
+	if (deltatick > systemtickfrequency) {
+		starttick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+		Stats.FPS = FPS_temp - 1;
+		FPS_temp = 0;
+		*(Shared.FPS) = Stats.FPS;
+		if (changeFPS && !configRC && FPSlock) {
+			LOCK::applyPatch(configBuffer, configSize, FPSlock);
+			*(Shared.patchApplied) = 1;
+		}
+	}
+
+	*(Shared.FPSavg) = Stats.FPSavg;
+	*(Shared.pluginActive) = true;
+
+	if (FPSlock != *(Shared.FPSlocked)) {
+		if ((*(Shared.FPSlocked) < 60) && (*(Shared.FPSlocked) > 0)) {
+			FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 6000;
+		}
+		else FPStiming = 0;
+		FPSlock = *(Shared.FPSlocked);
+	}
+	
+	return vulkanResult;
+}
+
+uint32_t vulkanSwap (void* VkQueue, void* VkPresentInfoKHR) {
+	static uint8_t FPS_temp = 0;
+	static uint64_t starttick = 0;
+	static uint64_t endtick = 0;
+	static uint64_t deltatick = 0;
+	static uint64_t frameend = 0;
+	static uint64_t framedelta = 0;
+	static uint64_t frameavg = 0;
+	static uint8_t FPSlock = 0;
+	static uint32_t FPStiming = 0;
+	static uint8_t FPStickItr = 0;
+	static uint8_t range = 0;
+	
+	bool FPSlock_delayed = false;
+	
+	if (!starttick) {
+		*(Shared.API) = 3;
+		starttick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	}
+	if (FPStiming && !LOCK::blockDelayFPS) {
+		if ((((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))() - frameend) < FPStiming) {
+			FPSlock_delayed = true;
+		}
+		while ((((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))() - frameend) < FPStiming) {
+			svcSleepThread(-2);
+		}
+	}
+
+	uint32_t vulkanResult = ((vkQueuePresentKHR_0)(Address_weaks.vkQueuePresentKHR))(VkQueue, VkPresentInfoKHR);
+	endtick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	framedelta = endtick - frameend;
+	frameavg = ((9*frameavg) + framedelta) / 10;
+	Stats.FPSavg = systemtickfrequency / (float)frameavg;
+
+	if (FPSlock_delayed && FPStiming) {
+		if (Stats.FPSavg > ((float)FPSlock)) {
+			if (range < 200) {
+				FPStiming += 20;
+				range++;
+			}
+		}
+		else if ((std::lround(Stats.FPSavg) == FPSlock) && (Stats.FPSavg < (float)FPSlock)) {
+			if (range > 0) {
+				FPStiming -= 20;
+				range--;
+			}
+		}
+	}
+
+	frameend = endtick;
+	
+	FPS_temp++;
+	deltatick = endtick - starttick;
+
+	Shared.FPSticks[FPStickItr++] = framedelta;
+	FPStickItr %= 10;
+
+	if (deltatick > systemtickfrequency) {
+		starttick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+		Stats.FPS = FPS_temp - 1;
+		FPS_temp = 0;
+		*(Shared.FPS) = Stats.FPS;
+		if (changeFPS && !configRC && FPSlock) {
+			LOCK::applyPatch(configBuffer, configSize, FPSlock);
+			*(Shared.patchApplied) = 1;
+		}
+	}
+
+	*(Shared.FPSavg) = Stats.FPSavg;
+	*(Shared.pluginActive) = true;
+
+	if (FPSlock != *(Shared.FPSlocked)) {
+		if ((*(Shared.FPSlocked) < 60) && (*(Shared.FPSlocked) > 0)) {
+			FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 6000;
+		}
+		else FPStiming = 0;
+		FPSlock = *(Shared.FPSlocked);
+	}
+	
+	return vulkanResult;
+}
+
+int eglInterval(void* EGLDisplay, int interval) {
+	int result = false;
+	if (!changeFPS) {
+		result = ((eglSwapInterval_0)(Address_weaks.eglSwapInterval))(EGLDisplay, interval);
+		changedFPS = false;
+		*(Shared.FPSmode) = interval;
+	}
+	else if (interval < 0) {
+		interval *= -1;
+		if (*(Shared.FPSmode) != interval) {
+			result = ((eglSwapInterval_0)(Address_weaks.eglSwapInterval))(EGLDisplay, interval);
+			*(Shared.FPSmode) = interval;
+		}
+		changedFPS = true;
+	}
+	return result;
+}
+
+int eglSwap (void* EGLDisplay, void* EGLSurface) {
+	static uint8_t FPS_temp = 0;
+	static uint64_t starttick = 0;
+	static uint64_t endtick = 0;
+	static uint64_t deltatick = 0;
+	static uint64_t frameend = 0;
+	static uint64_t framedelta = 0;
+	static uint64_t frameavg = 0;
+	static uint8_t FPSlock = 0;
+	static uint32_t FPStiming = 0;
+	static uint8_t FPStickItr = 0;
+	static uint8_t range = 0;
+	
+	bool FPSlock_delayed = false;
+
+	if (!starttick) {
+		*(Shared.API) = 2;
+		starttick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	}
+	if (FPStiming && !LOCK::blockDelayFPS) {
+		if ((((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))() - frameend) < FPStiming) {
+			FPSlock_delayed = true;
+		}
+		while ((((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))() - frameend) < FPStiming) {
+			svcSleepThread(-2);
+		}
+	}
+	
+	int result = ((eglSwapBuffers_0)(Address_weaks.eglSwapBuffers))(EGLDisplay, EGLSurface);
+	endtick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	framedelta = endtick - frameend;
+	frameavg = ((9*frameavg) + framedelta) / 10;
+	Stats.FPSavg = systemtickfrequency / (float)frameavg;
+
+	if (FPSlock_delayed && FPStiming) {
+		if (Stats.FPSavg > ((float)FPSlock)) {
+			if (range < 200) {
+				FPStiming += 20;
+				range++;
+			}
+		}
+		else if ((std::lround(Stats.FPSavg) == FPSlock) && (Stats.FPSavg < (float)FPSlock)) {
+			if (range > 0) {
+				FPStiming -= 20;
+				range--;
+			}
+		}
+	}
+
+	frameend = endtick;
+	
+	FPS_temp++;
+	deltatick = endtick - starttick;
+
+	Shared.FPSticks[FPStickItr++] = framedelta;
+	FPStickItr %= 10;
+
+	if (deltatick > systemtickfrequency) {
+		starttick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+		Stats.FPS = FPS_temp - 1;
+		FPS_temp = 0;
+		*(Shared.FPS) = Stats.FPS;
+		if (changeFPS && !configRC && FPSlock) {
+			LOCK::applyPatch(configBuffer, configSize, FPSlock);
+			*(Shared.patchApplied) = 1;
+		}
+	}
+	
+	*(Shared.FPSavg) = Stats.FPSavg;
+	*(Shared.pluginActive) = true;
+
+	if (FPSlock != *(Shared.FPSlocked)) {
+		changeFPS = true;
+		changedFPS = false;
+		if (*(Shared.FPSlocked) == 0) {
+			FPStiming = 0;
+			changeFPS = false;
+			FPSlock = *(Shared.FPSlocked);
+		}
+		else if (*(Shared.FPSlocked) <= 30) {
+			eglInterval(EGLDisplay, -2);
+			if (*(Shared.FPSlocked) != 30) {
+				FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 6000;
+			}
+			else FPStiming = 0;
+		}
+		else {
+			eglInterval(EGLDisplay, -1);
+			if (*(Shared.FPSlocked) != 60) {
+				FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 6000;
+			}
+			else FPStiming = 0;
+		}
+		if (changedFPS) {
+			FPSlock = *(Shared.FPSlocked);
+		}
+	}
+
+	return result;
+}
+
+void nvnWindowBuilderSetTextures(void* nvnWindowBuilder, int numBufferedFrames, void* nvnTextures) {
+	*(Shared.Buffers) = numBufferedFrames;
+	if (*(Shared.SetBuffers) >= 2 && *(Shared.SetBuffers) <= numBufferedFrames) {
+		numBufferedFrames = *(Shared.SetBuffers);
+	}
+	*(Shared.ActiveBuffers) = numBufferedFrames;
+	return ((nvnBuilderSetTextures_0)(Ptrs.nvnWindowBuilderSetTextures))(nvnWindowBuilder, numBufferedFrames, nvnTextures);
+}
+
+void nvnWindowSetNumActiveTextures(void* nvnWindow, int numBufferedFrames) {
+	*(Shared.SetActiveBuffers) = numBufferedFrames;
+	if (*(Shared.SetBuffers) >= 2 && *(Shared.SetBuffers) <= *(Shared.Buffers)) {
+		numBufferedFrames = *(Shared.SetBuffers);
+	}
+	*(Shared.ActiveBuffers) = numBufferedFrames;
+	return ((nvnWindowSetNumActiveTextures_0)(Ptrs.nvnWindowSetNumActiveTextures))(nvnWindow, numBufferedFrames);
+}
+
+void nvnSetPresentInterval(void* nvnWindow, int mode) {
+	if (!changeFPS) {
+		((nvnSetPresentInterval_0)(Ptrs.nvnWindowSetPresentInterval))(nvnWindow, mode);
+		changedFPS = false;
+		*(Shared.FPSmode) = mode;
+	}
+	else if (mode < 0) {
+		mode *= -1;
+		if (*(Shared.FPSmode) != mode) {
+			((nvnSetPresentInterval_0)(Ptrs.nvnWindowSetPresentInterval))(nvnWindow, mode);
+			*(Shared.FPSmode) = mode;
+		}
+		changedFPS = true;
+	}
+	return;
+}
+
+void* nvnSyncWait0(void* _this, uint64_t timeout_ns) {
+	uint64_t endFrameTick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	if (_this == WindowSync) {
+		if (*(Shared.ZeroSync) == ZeroSyncType_Semi) {
+			u64 FrameTarget = (systemtickfrequency/60) - 8000;
+			s64 new_timeout = (FrameTarget - (endFrameTick - startFrameTick)) - 19200;
+			if (*(Shared.FPSlocked) == 60) {
+				new_timeout = (systemtickfrequency/101) - (endFrameTick - startFrameTick);
+			}
+			if (new_timeout > 0) {
+				timeout_ns = ((_ZN2nn2os17ConvertToTimeSpanENS0_4TickE_0)(Address_weaks.ConvertToTimeSpan))(new_timeout);
+			}
+			else timeout_ns = 0;
+		}
+		else if (*(Shared.ZeroSync) == ZeroSyncType_Soft) 
+			timeout_ns = 0;
+	}
+	return ((nvnSyncWait_0)(Ptrs.nvnSyncWait))(_this, timeout_ns);
+}
+
+void nvnPresentTexture(void* _this, void* nvnWindow, void* unk3) {
+	static uint8_t FPS_temp = 0;
+	static uint64_t starttick = 0;
+	static uint64_t endtick = 0;
+	static uint64_t deltatick = 0;
+	static uint64_t frameend = 0;
+	static uint64_t framedelta = 0;
+	static uint64_t frameavg = 0;
+	static uint8_t FPSlock = 0;
+	static uint32_t FPStiming = 0;
+	static uint8_t FPStickItr = 0;
+	static uint8_t range = 0;
+	
+	bool FPSlock_delayed = false;
+
+	if (!starttick) {
+		starttick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+		*(Shared.FPSmode) = (uint8_t)((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow);
+	}
+	
+	if (FPSlock) {
+		if ((*(Shared.ZeroSync) == ZeroSyncType_None) && FPStiming && (FPSlock == 60 || FPSlock == 30)) {
+			FPStiming = 0;
+		}
+		else if ((*(Shared.ZeroSync) != ZeroSyncType_None) && !FPStiming) {
+			if (FPSlock == 60) {
+				FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 8000;
+			}
+			else FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 6000;
+		}
+	}
+
+	if (FPStiming && !LOCK::blockDelayFPS) {
+		if ((((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))() - frameend) < FPStiming) {
+			FPSlock_delayed = true;
+		}
+		while ((((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))() - frameend) < FPStiming) {
+			svcSleepThread(-2);
+		}
+	}
+	
+	((nvnQueuePresentTexture_0)(Ptrs.nvnQueuePresentTexture))(_this, nvnWindow, unk3);
+	endtick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	framedelta = endtick - frameend;
+
+	Shared.FPSticks[FPStickItr++] = framedelta;
+	FPStickItr %= 10;
+	
+	frameavg = ((9*frameavg) + framedelta) / 10;
+	Stats.FPSavg = systemtickfrequency / (float)frameavg;
+
+	if (FPSlock_delayed && FPStiming) {
+		if (Stats.FPSavg > ((float)FPSlock)) {
+			if (range < 200) {
+				FPStiming += 20;
+				range++;
+			}
+		}
+		else if ((std::lround(Stats.FPSavg) == FPSlock) && (Stats.FPSavg < (float)FPSlock)) {
+			if (range > 0) {
+				FPStiming -= 20;
+				range--;
+			}
+		}
+	}
+
+	frameend = endtick;
+	FPS_temp++;
+	deltatick = endtick - starttick;
+	if (deltatick > systemtickfrequency) {
+		starttick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+		Stats.FPS = FPS_temp - 1;
+		FPS_temp = 0;
+		*(Shared.FPS) = Stats.FPS;
+		*(Shared.FPSmode) = (uint8_t)((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow);
+		if (changeFPS && !configRC && FPSlock) {
+			LOCK::applyPatch(configBuffer, configSize, FPSlock);
+			*(Shared.patchApplied) = 1;
+		}
+	}
+
+	*(Shared.FPSavg) = Stats.FPSavg;
+	*(Shared.pluginActive) = true;
+
+	if (FPSlock != *(Shared.FPSlocked)) {
+		changeFPS = true;
+		changedFPS = false;
+		if (*(Shared.FPSlocked) == 0) {
+			FPStiming = 0;
+			changeFPS = false;
+			FPSlock = *(Shared.FPSlocked);
+		}
+		else if (*(Shared.FPSlocked) <= 30) {
+			nvnSetPresentInterval(nvnWindow, -2);
+			if (*(Shared.FPSlocked) != 30 || *(Shared.ZeroSync)) {
+				if (*(Shared.FPSlocked) == 30) {
+					FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 8000;
+				}
+				else FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 6000;
+			}
+			else FPStiming = 0;
+		}
+		else {
+			nvnSetPresentInterval(nvnWindow, -2); //This allows in game with glitched interval to unlock 60 FPS, f.e. WRC Generations
+			nvnSetPresentInterval(nvnWindow, -1);
+			if (*(Shared.FPSlocked) != 60 || *(Shared.ZeroSync)) {
+				if (*(Shared.FPSlocked) == 60) {
+					FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 8000;
+				}
+				else FPStiming = (systemtickfrequency/(*(Shared.FPSlocked))) - 6000;
+			}
+			else FPStiming = 0;
+		}
+		if (changedFPS) {
+			FPSlock = *(Shared.FPSlocked);
+		}
+	}
+	
+	return;
+}
+
+void* nvnAcquireTexture(void* nvnWindow, void* nvnSync, void* index) {
+	if (WindowSync != nvnSync) {
+		WindowSync = nvnSync;
+	}
+	void* ret = ((nvnWindowAcquireTexture_0)(Ptrs.nvnWindowAcquireTexture))(nvnWindow, nvnSync, index);
+	startFrameTick = ((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))();
+	return ret;
+}
+
+uintptr_t nvnGetProcAddress (void* unk1, const char* nvnFunction) {
+	uintptr_t address = ((GetProcAddress)(Ptrs.nvnDeviceGetProcAddress))(unk1, nvnFunction);
+	if (!strcmp("nvnDeviceGetProcAddress", nvnFunction))
+		return Address.nvnGetProcAddress;
+	else if (!strcmp("nvnQueuePresentTexture", nvnFunction)) {
+		Ptrs.nvnQueuePresentTexture = address;
+		return Address.nvnQueuePresentTexture;
+	}
+	else if (!strcmp("nvnWindowAcquireTexture", nvnFunction)) {
+		Ptrs.nvnWindowAcquireTexture = address;
+		return Address.nvnWindowAcquireTexture;
+	}
+	else if (!strcmp("nvnWindowSetPresentInterval", nvnFunction)) {
+		Ptrs.nvnWindowSetPresentInterval = address;
+		return Address.nvnWindowSetPresentInterval;
+	}
+	else if (!strcmp("nvnWindowGetPresentInterval", nvnFunction)) {
+		Ptrs.nvnWindowGetPresentInterval = address;
+		return address;
+	}
+	else if (!strcmp("nvnWindowSetNumActiveTextures", nvnFunction)) {
+		Ptrs.nvnWindowSetNumActiveTextures = address;
+		return Address.nvnWindowSetNumActiveTextures;
+	}
+	else if (!strcmp("nvnWindowBuilderSetTextures", nvnFunction)) {
+		Ptrs.nvnWindowBuilderSetTextures = address;
+		return Address.nvnWindowBuilderSetTextures;
+	}
+	else if (!strcmp("nvnSyncWait", nvnFunction)) {
+		Ptrs.nvnSyncWait = address;
+		return Address.nvnSyncWait;
+	}
+	else return address;
+}
+
+uintptr_t nvnBootstrapLoader_1(const char* nvnName) {
+	if (strcmp(nvnName, "nvnDeviceGetProcAddress") == 0) {
+		*(Shared.API) = 1;
+		Ptrs.nvnDeviceGetProcAddress = ((nvnBootstrapLoader_0)(Address_weaks.nvnBootstrapLoader))("nvnDeviceGetProcAddress");
+		return Address.nvnGetProcAddress;
+	}
+	uintptr_t ptrret = ((nvnBootstrapLoader_0)(Address_weaks.nvnBootstrapLoader))(nvnName);
+	return ptrret;
+}
+
+extern "C" {
+
+	void NX_FPS() {
+		SaltySDCore_printf("NX-FPS: alive\n");
+		LOCK::mappings.main_start = getMainAddress();
+		SaltySDCore_printf("NX-FPS: found main at: 0x%lX\n", LOCK::mappings.main_start);
+		Result ret = SaltySD_CheckIfSharedMemoryAvailable(&SharedMemoryOffset, 59);
+		SaltySDCore_printf("NX-FPS: ret: 0x%X\n", ret);
+		if (!ret) {
+			SaltySDCore_printf("NX-FPS: MemoryOffset: %d\n", SharedMemoryOffset);
+			SaltySD_GetSharedMemoryHandle(&remoteSharedMemory);
+			shmemLoadRemote(&_sharedmemory, remoteSharedMemory, 0x1000, Perm_Rw);
+			ret = shmemMap(&_sharedmemory);
+			if (R_SUCCEEDED(ret)) {
+				uintptr_t base = (uintptr_t)shmemGetAddr(&_sharedmemory) + SharedMemoryOffset;
+				uint32_t* MAGIC = (uint32_t*)base;
+				*MAGIC = 0x465053;
+				Shared.FPS = (uint8_t*)(base + 4);
+				Shared.FPSavg = (float*)(base + 5);
+				Shared.pluginActive = (bool*)(base + 9);
+				
+				Address.nvnGetProcAddress = (uint64_t)&nvnGetProcAddress;
+				Address.nvnQueuePresentTexture = (uint64_t)&nvnPresentTexture;
+				Address.nvnWindowAcquireTexture = (uint64_t)&nvnAcquireTexture;
+				Address_weaks.nvnBootstrapLoader = SaltySDCore_FindSymbolBuiltin("nvnBootstrapLoader");
+				Address_weaks.eglSwapBuffers = SaltySDCore_FindSymbolBuiltin("eglSwapBuffers");
+				Address_weaks.eglSwapInterval = SaltySDCore_FindSymbolBuiltin("eglSwapInterval");
+				Address_weaks.vkQueuePresentKHR = SaltySDCore_FindSymbolBuiltin("vkQueuePresentKHR");
+				Address_weaks.nvSwapchainQueuePresentKHR = SaltySDCore_FindSymbolBuiltin("_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR");
+				Address_weaks.ConvertToTimeSpan = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os17ConvertToTimeSpanENS0_4TickE");
+				Address_weaks.GetSystemTick = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os13GetSystemTickEv");
+				SaltySDCore_ReplaceImport("nvnBootstrapLoader", (void*)nvnBootstrapLoader_1);
+				SaltySDCore_ReplaceImport("eglSwapBuffers", (void*)eglSwap);
+				SaltySDCore_ReplaceImport("eglSwapInterval", (void*)eglInterval);
+				SaltySDCore_ReplaceImport("vkQueuePresentKHR", (void*)vulkanSwap);
+				SaltySDCore_ReplaceImport("_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR", (void*)vulkanSwap2);
+
+				Shared.FPSlocked = (uint8_t*)(base + 10);
+				Shared.FPSmode = (uint8_t*)(base + 11);
+				Shared.ZeroSync = (uint8_t*)(base + 12);
+				Shared.patchApplied = (uint8_t*)(base + 13);
+				Shared.API = (uint8_t*)(base + 14);
+				Shared.FPSticks = (uint32_t*)(base + 15);
+				Shared.Buffers = (uint8_t*)(base + 55);
+				Shared.SetBuffers = (uint8_t*)(base + 56);
+				Shared.ActiveBuffers = (uint8_t*)(base + 57);
+				Shared.SetActiveBuffers = (uint8_t*)(base + 58);
+				Address.nvnWindowSetPresentInterval = (uint64_t)&nvnSetPresentInterval;
+				Address.nvnSyncWait = (uint64_t)&nvnSyncWait0;
+				Address.nvnWindowBuilderSetTextures = (uint64_t)&nvnWindowBuilderSetTextures;
+				Address.nvnWindowSetNumActiveTextures = (uint64_t)&nvnWindowSetNumActiveTextures;
+
+				char titleid[17];
+				CheckTitleID(&titleid[0]);
+				char path[128];
+				strcpy(&path[0], "sdmc:/SaltySD/plugins/FPSLocker/0");
+				strcat(&path[0], &titleid[0]);
+				strcat(&path[0], ".dat");
+				FILE* file_dat = SaltySDCore_fopen(path, "rb");
+				if (file_dat) {
+					uint8_t temp = 0;
+					SaltySDCore_fread(&temp, 1, 1, file_dat);
+					*(Shared.FPSlocked) = temp;
+					SaltySDCore_fread(&temp, 1, 1, file_dat);
+					*(Shared.ZeroSync) = temp;
+					if (SaltySDCore_fread(&temp, 1, 1, file_dat))
+						*(Shared.SetBuffers) = temp;
+					SaltySDCore_fclose(file_dat);
+				}
+
+				u64 buildid = SaltySD_GetBID();
+				if (!buildid) {
+					SaltySDCore_printf("NX-FPS: getBID failed! Err: 0x%x\n", ret);
+				}
+				else {
+					SaltySDCore_printf("NX-FPS: BID: %016lX\n", buildid);
+					createBuildidPath(buildid, &titleid[0], &path[0]);
+					FILE* patch_file = SaltySDCore_fopen(path, "rb");
+					if (patch_file) {
+						SaltySDCore_fclose(patch_file);
+						SaltySDCore_printf("NX-FPS: FPSLocker: successfully opened: %s\n", path);
+						configRC = readConfig(path, &configBuffer);
+						if (LOCK::MasterWriteApplied) {
+							*(Shared.patchApplied) = 2;
+						}
+						SaltySDCore_printf("NX-FPS: FPSLocker: readConfig rc: 0x%x\n", configRC);
+						svcGetInfo(&LOCK::mappings.alias_start, InfoType_AliasRegionAddress, CUR_PROCESS_HANDLE, 0);
+						svcGetInfo(&LOCK::mappings.heap_start, InfoType_HeapRegionAddress, CUR_PROCESS_HANDLE, 0);
+					}
+					else SaltySDCore_printf("NX-FPS: FPSLocker: File not found: %s\n", path);
+				}
+			}
+			else {
+				SaltySDCore_printf("NX-FPS: shmemMap failed! Err: 0x%x\n", ret);
+			}
+		}
+		SaltySDCore_printf("NX-FPS: injection finished\n");
+	}
+}

--- a/saltysd_core/source/NX-FPS.h
+++ b/saltysd_core/source/NX-FPS.h
@@ -1,1 +1,1 @@
-void NX_FPS();
+void NX_FPS(SharedMemory* _sharedmemory);

--- a/saltysd_core/source/NX-FPS.h
+++ b/saltysd_core/source/NX-FPS.h
@@ -1,0 +1,1 @@
+void NX_FPS();

--- a/saltysd_core/source/ReverseNX.cpp
+++ b/saltysd_core/source/ReverseNX.cpp
@@ -1,0 +1,283 @@
+#include <switch_min.h>
+
+#include "saltysd_core.h"
+#include "saltysd_ipc.h"
+#include "saltysd_dynamic.h"
+
+struct SystemEvent {
+	const char reserved[16];
+	bool flag;
+};
+
+extern "C" {
+	typedef u32 (*_ZN2nn2oe18GetPerformanceModeEv)();
+	typedef u8 (*_ZN2nn2oe16GetOperationModeEv)();
+	typedef bool (*_ZN2nn2oe25TryPopNotificationMessageEPj)(int &Message);
+	typedef int (*_ZN2nn2oe22PopNotificationMessageEv)();
+	typedef void (*_ZN2nn2oe27GetDefaultDisplayResolutionEPiS1_)(int* width, int* height);
+	typedef void (*_ZN2nn2oe38GetDefaultDisplayResolutionChangeEventEPNS_2os11SystemEventE)(SystemEvent* systemEvent);
+	typedef bool (*nnosTryWaitSystemEvent)(SystemEvent* systemEvent);
+	typedef SystemEvent* (*_ZN2nn2oe27GetNotificationMessageEventEv)();
+	typedef void (*nnosInitializeMultiWaitHolderForSystemEvent)(void* MultiWaitHolderType, SystemEvent* systemEvent);
+	typedef void (*nnosLinkMultiWaitHolder)(void* MultiWaitType, void* MultiWaitHolderType);
+	typedef void* (*nnosWaitAny)(void* MultiWaitType);
+	typedef void* (*nnosTimedWaitAny)(void* MultiWaitType, u64 TimeSpan);
+}
+
+struct {
+	uintptr_t GetPerformanceMode;
+	uintptr_t GetOperationMode;
+	uintptr_t TryPopNotificationMessage;
+	uintptr_t PopNotificationMessage;
+	uintptr_t GetDefaultDisplayResolution;
+	uintptr_t GetDefaultDisplayResolutionChangeEvent;
+	uintptr_t TryWaitSystemEvent;
+	uintptr_t GetNotificationMessageEvent;
+	uintptr_t InitializeMultiWaitHolderForSystemEvent;
+	uintptr_t LinkMultiWaitHolder;
+	uintptr_t WaitAny;
+	uintptr_t TimedWaitAny;	
+} Address_weaks;
+
+bool* def_shared = 0;
+bool* isDocked_shared = 0;
+bool* pluginActive_shared = 0;
+const char* ver = "2.0.0";
+
+ptrdiff_t SharedMemoryOffset2 = -1;
+
+SystemEvent* defaultDisplayResolutionChangeEventCopy = 0;
+SystemEvent* notificationMessageEventCopy = 0;
+void* multiWaitHolderCopy = 0;
+void* multiWaitCopy = 0;
+
+bool TryPopNotificationMessage(int &msg) {
+
+	static bool check1 = true;
+	static bool check2 = true;
+	static bool compare = false;
+	static bool compare2 = false;
+
+	*pluginActive_shared = true;
+
+	if (*def_shared) {
+		if (!check1) {
+			check1 = true;
+			msg = 0x1f;
+			return true;
+		}
+		else if (!check2) {
+			check2 = true;
+			msg = 0x1e;
+			return true;
+		}
+		else return ((_ZN2nn2oe25TryPopNotificationMessageEPj)(Address_weaks.TryPopNotificationMessage))(msg);
+	}
+	
+	check1 = false;
+	check2 = false;
+	if (compare2 != *isDocked_shared) {
+		compare2 = *isDocked_shared;
+		msg = 0x1f;
+		return true;
+	}
+	if (compare != *isDocked_shared) {
+		compare = *isDocked_shared;
+		msg = 0x1e;
+		return true;
+	}
+	
+	return ((_ZN2nn2oe25TryPopNotificationMessageEPj)(Address_weaks.TryPopNotificationMessage))(msg);
+}
+
+int PopNotificationMessage() {
+	
+	static bool check1 = true;
+	static bool check2 = true;
+	static bool compare = false;
+	static bool compare2 = false;
+	
+	*pluginActive_shared = true;
+	
+	if (*def_shared) {
+		if (!check1) {
+			check1 = true;
+			return 0x1e;
+		}
+		else if (!check2) {
+			check2 = true;
+			return 0x1f;
+		}
+		else return ((_ZN2nn2oe22PopNotificationMessageEv)(Address_weaks.PopNotificationMessage))();
+	}
+	
+	check1 = false;
+	check2 = false;
+
+	if (compare2 != *isDocked_shared) {
+		compare2 = *isDocked_shared;
+		return 0x1e;
+	}
+	else if (compare != *isDocked_shared) {
+		compare = *isDocked_shared;
+		return 0x1f;
+	}
+	
+	return ((_ZN2nn2oe22PopNotificationMessageEv)(Address_weaks.PopNotificationMessage))();
+}
+
+uint32_t GetPerformanceMode() {
+	if (*def_shared) *isDocked_shared = ((_ZN2nn2oe18GetPerformanceModeEv)(Address_weaks.GetPerformanceMode))();
+	
+	return *isDocked_shared;
+}
+
+uint8_t GetOperationMode() {
+	if (*def_shared) *isDocked_shared = ((_ZN2nn2oe16GetOperationModeEv)(Address_weaks.GetOperationMode))();
+	
+	return *isDocked_shared;
+}
+
+/* 
+	Used by Red Dead Redemption.
+
+	Without using functions above, mode is detected by checking what is
+	default display resolution of currently running mode.
+	Those are:
+	Handheld - 1280x720
+	Docked - 1920x1080
+	
+	Game is waiting for DefaultDisplayResolutionChange event to check again
+	which mode is currently in use. And to do that nn::os::TryWaitSystemEvent is used
+	that is always returning flag without waiting for it to change.
+	
+	So solution is to replace flag returned by nn::os::TryWaitSystemEvent
+	when DefaultDisplayResolutionChange event is passed as argument,
+	and replace values written by nn::oe::GetDefaultDisplayResolution.
+
+*/
+void GetDefaultDisplayResolution(int* width, int* height) {
+	if (*def_shared) {
+		((_ZN2nn2oe27GetDefaultDisplayResolutionEPiS1_)(Address_weaks.GetDefaultDisplayResolution))(width, height);
+		if (*width == 1920) *isDocked_shared = true;
+		else *isDocked_shared = false;
+	}
+	else if (*isDocked_shared) {
+		*width = 1920;
+		*height = 1080;
+	}
+	else {
+		*width = 1280;
+		*height = 720;
+	}
+}
+
+void GetDefaultDisplayResolutionChangeEvent(SystemEvent* systemEvent) {
+	((_ZN2nn2oe38GetDefaultDisplayResolutionChangeEventEPNS_2os11SystemEventE)(Address_weaks.GetDefaultDisplayResolutionChangeEvent))(systemEvent);
+	defaultDisplayResolutionChangeEventCopy = systemEvent;
+}
+
+bool TryWaitSystemEvent(SystemEvent* systemEvent) {
+	static bool check = true;
+	static bool compare = false;
+
+	if (systemEvent != defaultDisplayResolutionChangeEventCopy || *def_shared) {
+		bool ret = ((nnosTryWaitSystemEvent)(Address_weaks.TryWaitSystemEvent))(systemEvent);
+		compare = *isDocked_shared;
+		if (systemEvent == defaultDisplayResolutionChangeEventCopy && !check) {
+			check = true;
+			return true;
+		}
+		return ret;
+	}
+	check = false;
+	if (systemEvent == defaultDisplayResolutionChangeEventCopy) {
+		if (compare != *isDocked_shared) {
+			compare = *isDocked_shared;
+			return true;
+		}
+		return false;
+	}
+	return ((nnosTryWaitSystemEvent)(Address_weaks.TryWaitSystemEvent))(systemEvent);
+}
+
+/* 
+	Used by Monster Hunter Rise.
+
+	Game won't check if mode was changed until NotificationMessage event will be flagged.
+	Functions below are detecting which MultiWait includes NotificationMessage event,
+	and for that MultiWait passed as argument to nn::os::WaitAny it is redirected to nn::os::TimedWaitAny
+	with timeout set to 1ms so we can force game to check NotificationMessage every 1ms.
+
+	Almost all games are checking NotificationMessage in loops instead of waiting for event,
+	so even though this is not a clean solution, it works and performance impact is negligible.
+*/
+
+SystemEvent* GetNotificationMessageEvent() {
+	notificationMessageEventCopy = ((_ZN2nn2oe27GetNotificationMessageEventEv)(Address_weaks.GetNotificationMessageEvent))();
+	return notificationMessageEventCopy;
+}
+
+void InitializeMultiWaitHolder(void* MultiWaitHolderType, SystemEvent* systemEvent) {
+	((nnosInitializeMultiWaitHolderForSystemEvent)(Address_weaks.InitializeMultiWaitHolderForSystemEvent))(MultiWaitHolderType, systemEvent);
+	if (systemEvent == notificationMessageEventCopy) 
+		multiWaitHolderCopy = MultiWaitHolderType;
+}
+
+void LinkMultiWaitHolder(void* MultiWaitType, void* MultiWaitHolderType) {
+	((nnosLinkMultiWaitHolder)(Address_weaks.LinkMultiWaitHolder))(MultiWaitType, MultiWaitHolderType);
+	if (MultiWaitHolderType == multiWaitHolderCopy)
+		multiWaitCopy = MultiWaitType;
+}
+
+void* WaitAny(void* MultiWaitType) {
+	if (multiWaitCopy != MultiWaitType)
+		return ((nnosWaitAny)(Address_weaks.WaitAny))(MultiWaitType);
+	return ((nnosTimedWaitAny)(Address_weaks.TimedWaitAny))(MultiWaitType, 1000000);
+}
+
+extern "C" {
+	void ReverseNX(SharedMemory* _sharedmemory) {
+		SaltySDCore_printf("ReverseNX: alive\n");
+		Result ret = SaltySD_CheckIfSharedMemoryAvailable(&SharedMemoryOffset2, 7);
+		SaltySDCore_printf("ReverseNX: SharedMemory ret: 0x%X\n", ret);
+		if (!ret) {
+			SaltySDCore_printf("ReverseNX: SharedMemory MemoryOffset: %d\n", SharedMemoryOffset2);
+
+			uintptr_t base = (uintptr_t)shmemGetAddr(_sharedmemory) + SharedMemoryOffset2;
+			uint32_t* MAGIC = (uint32_t*)base;
+			*MAGIC = 0x5452584E;
+			isDocked_shared = (bool*)(base + 4);
+			def_shared = (bool*)(base + 5);
+			pluginActive_shared = (bool*)(base + 6);
+			*isDocked_shared = false;
+			*def_shared = true;
+			*pluginActive_shared = false;
+			Address_weaks.GetPerformanceMode = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe18GetPerformanceModeEv");
+			Address_weaks.GetOperationMode = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe16GetOperationModeEv");
+			Address_weaks.TryPopNotificationMessage = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe25TryPopNotificationMessageEPj");
+			Address_weaks.PopNotificationMessage = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe22PopNotificationMessageEv");
+			Address_weaks.GetDefaultDisplayResolution = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe27GetDefaultDisplayResolutionEPiS1_");
+			Address_weaks.GetDefaultDisplayResolutionChangeEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe38GetDefaultDisplayResolutionChangeEventEPNS_2os11SystemEventE");
+			Address_weaks.TryWaitSystemEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os18TryWaitSystemEventEPNS0_15SystemEventTypeE");
+			Address_weaks.GetNotificationMessageEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe27GetNotificationMessageEventEv");
+			Address_weaks.InitializeMultiWaitHolderForSystemEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os25InitializeMultiWaitHolderEPNS0_19MultiWaitHolderTypeEPNS0_15SystemEventTypeE");
+			Address_weaks.LinkMultiWaitHolder = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os19LinkMultiWaitHolderEPNS0_13MultiWaitTypeEPNS0_19MultiWaitHolderTypeE");
+			Address_weaks.WaitAny = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os7WaitAnyEPNS0_13MultiWaitTypeE");
+			Address_weaks.TimedWaitAny = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os12TimedWaitAnyEPNS0_13MultiWaitTypeENS_8TimeSpanE");
+			SaltySDCore_ReplaceImport("_ZN2nn2oe25TryPopNotificationMessageEPj", (void*)TryPopNotificationMessage);
+			SaltySDCore_ReplaceImport("_ZN2nn2oe22PopNotificationMessageEv", (void*)PopNotificationMessage);
+			SaltySDCore_ReplaceImport("_ZN2nn2oe18GetPerformanceModeEv", (void*)GetPerformanceMode);
+			SaltySDCore_ReplaceImport("_ZN2nn2oe16GetOperationModeEv", (void*)GetOperationMode);
+			SaltySDCore_ReplaceImport("_ZN2nn2oe27GetDefaultDisplayResolutionEPiS1_", (void*)GetDefaultDisplayResolution);
+			SaltySDCore_ReplaceImport("_ZN2nn2oe38GetDefaultDisplayResolutionChangeEventEPNS_2os11SystemEventE", (void*)GetDefaultDisplayResolutionChangeEvent);
+			SaltySDCore_ReplaceImport("_ZN2nn2os18TryWaitSystemEventEPNS0_15SystemEventTypeE", (void*)TryWaitSystemEvent);
+			SaltySDCore_ReplaceImport("_ZN2nn2oe27GetNotificationMessageEventEv", (void*)GetNotificationMessageEvent);
+			SaltySDCore_ReplaceImport("_ZN2nn2os25InitializeMultiWaitHolderEPNS0_19MultiWaitHolderTypeEPNS0_15SystemEventTypeE", (void*)InitializeMultiWaitHolder);
+			SaltySDCore_ReplaceImport("_ZN2nn2os19LinkMultiWaitHolderEPNS0_13MultiWaitTypeEPNS0_19MultiWaitHolderTypeE", (void*)LinkMultiWaitHolder);
+			SaltySDCore_ReplaceImport("_ZN2nn2os7WaitAnyEPNS0_13MultiWaitTypeE", (void*)WaitAny);
+		}
+		
+		SaltySDCore_printf("ReverseNX: injection finished\n");
+	}
+}

--- a/saltysd_core/source/ReverseNX.h
+++ b/saltysd_core/source/ReverseNX.h
@@ -1,0 +1,1 @@
+void ReverseNX(SharedMemory* _sharedmemory);

--- a/saltysd_core/source/lock.hpp
+++ b/saltysd_core/source/lock.hpp
@@ -1,0 +1,438 @@
+#pragma once
+#define NOINLINE __attribute__ ((noinline))
+/* Design file how to build binary file for FPSLocker.
+
+1. Helper functions */
+
+namespace LOCK {
+
+	uint32_t offset = 0;
+	bool blockDelayFPS = false;
+	uint8_t gen = 0;
+	bool MasterWriteApplied = false;
+
+	struct {
+		int64_t main_start;
+		uint64_t alias_start;
+		uint64_t heap_start;
+	} mappings;
+
+	template <typename T>
+	bool compareValues(T value1, T value2, uint8_t compare_type) { // 1 - >, 2 - >=, 3 - <, 4 - <=, 5 - ==, 6 - !=
+		switch(compare_type) {
+			case 1:
+				return (value1 > value2);
+			case 2:
+				return (value1 >= value2);
+			case 3:
+				return (value1 < value2);
+			case 4:
+				return (value1 <= value2);
+			case 5:
+				return (value1 == value2);
+			case 6:
+				return (value1 != value2);
+		}
+		return false;
+	}
+
+	uint8_t read8(uint8_t* buffer) {
+		uint8_t ret = buffer[offset];
+		offset += sizeof(uint8_t);
+		return ret;
+	}
+
+	uint16_t read16(uint8_t* buffer) {
+		uint16_t ret = *(uint16_t*)(&buffer[offset]);
+		offset += sizeof(uint16_t);
+		return ret;
+	}
+
+	uint32_t read32(uint8_t* buffer) {
+		uint32_t ret = *(uint32_t*)(&buffer[offset]);
+		offset += sizeof(uint32_t);
+		return ret;
+	}
+
+	uint64_t read64(uint8_t* buffer) {
+		uint64_t ret = *(uint64_t*)(&buffer[offset]);
+		offset += sizeof(uint64_t);
+		return ret;
+	}
+
+	float readFloat(uint8_t* buffer) {
+		float ret = *(float*)(&buffer[offset]);
+		offset += sizeof(float);
+		return ret;
+	}
+
+	double readDouble(uint8_t* buffer) {
+		double ret = *(double*)(&buffer[offset]);
+		offset += sizeof(double);
+		return ret;
+	}
+
+	template <typename T>
+	void writeValue(T value, int64_t address) {
+		if (*(T*)address != value)
+			*(T*)address = value;
+	}
+
+	bool unsafeCheck = false;
+
+	bool NOINLINE isAddressValid(int64_t address) {
+		MemoryInfo memoryinfo = {0};
+		u32 pageinfo = 0;
+
+		if (unsafeCheck) return true;
+
+		if ((address < 0) || (address >= 0x8000000000)) return false;
+
+		Result rc = svcQueryMemory(&memoryinfo, &pageinfo, address);
+		if (R_FAILED(rc)) return false;
+		if ((memoryinfo.perm & Perm_Rw) && ((address - memoryinfo.addr >= 0) && (address - memoryinfo.addr <= memoryinfo.size)))
+			return true;
+		return false;
+	}
+
+	int64_t NOINLINE getAddress(uint8_t* buffer, uint8_t offsets_count) {
+		uint8_t region = read8(buffer);
+		offsets_count -= 1;
+		int64_t address = 0;
+		switch(region) {
+			case 1: {
+				address = mappings.main_start;
+				break;
+			}
+			case 2: {
+				address = mappings.heap_start;
+				break;
+			}
+			case 3: {
+				address = mappings.alias_start;
+				break;
+			}
+			default:
+				return -1;
+		}
+		for (int i = 0; i < offsets_count; i++) {
+			int32_t temp_offset = (int32_t)read32(buffer);
+			address += temp_offset;
+			if (i+1 < offsets_count) {
+				if (!isAddressValid(*(int64_t*)address)) return -2;
+				address = *(uint64_t*)address;
+			}
+		}
+		return address;
+	}
+
+
+///2. File format and reading
+
+	bool isValid(uint8_t* buffer, size_t filesize) {
+		if (*(uint32_t*)buffer != 0x4B434F4C)
+			return false;
+		gen = buffer[4];
+		if (gen < 1 || gen > 2)
+			return false;
+		if (*(uint16_t*)(&(buffer[5])) != 0)
+			return false;
+		if (buffer[7] > 1)
+			return false;
+		unsafeCheck = (bool)buffer[7];
+		uint8_t start_offset = 0x30;
+		if (gen == 2)
+			start_offset += 4;
+		if (*(uint32_t*)(&(buffer[8])) != start_offset)
+			return false;
+		return true;
+
+	}
+
+	Result applyMasterWrite(FILE* file, size_t filesize) {
+		uint32_t offset = 0;
+		if (gen != 2) return 0x311;
+
+		SaltySDCore_fseek(file, 0x30, 0);
+		SaltySDCore_fread(&offset, 4, 1, file);
+		SaltySDCore_fseek(file, offset, 0);
+		if (SaltySDCore_ftell(file) != offset)
+			return 0x312;
+		
+		int8_t OPCODE = 0;
+		while(true) {
+			SaltySDCore_fread(&OPCODE, 1, 1, file);
+			if (OPCODE == 1) {
+				uint32_t main_offset = 0;
+				SaltySDCore_fread(&main_offset, 4, 1, file);
+				uint8_t value_type = 0;
+				SaltySDCore_fread(&value_type, 1, 1, file);
+				uint8_t elements = 0;
+				SaltySDCore_fread(&elements, 1, 1, file);
+				switch(value_type) {
+					case 1:
+					case 0x11: {
+						void* temp_buffer = calloc(elements, 1);
+						SaltySDCore_fread(temp_buffer, 1, elements, file);
+						SaltySD_Memcpy(LOCK::mappings.main_start + main_offset, (u64)temp_buffer, elements);
+						free(temp_buffer);
+						break;
+					}
+					case 2:
+					case 0x12: {
+						void* temp_buffer = calloc(elements, 2);
+						SaltySDCore_fread(temp_buffer, 2, elements, file);
+						SaltySD_Memcpy(LOCK::mappings.main_start + main_offset, (u64)temp_buffer, elements*2);
+						free(temp_buffer);
+						break;
+					}
+					case 4:
+					case 0x14:
+					case 0x24: {
+						void* temp_buffer = calloc(elements, 4);
+						SaltySDCore_fread(temp_buffer, 4, elements, file);
+						SaltySD_Memcpy(LOCK::mappings.main_start + main_offset, (u64)temp_buffer, elements*4);
+						free(temp_buffer);
+						break;
+					}
+					case 8:
+					case 0x18:
+					case 0x28: {
+						void* temp_buffer = calloc(elements, 8);
+						SaltySDCore_fread(temp_buffer, 8, elements, file);
+						SaltySD_Memcpy(LOCK::mappings.main_start + main_offset, (u64)temp_buffer, elements*8);
+						free(temp_buffer);
+						break;
+					}
+					default:
+						return 0x313;
+				}				
+			}
+			else if (OPCODE == -1) {
+				MasterWriteApplied = true;
+				return 0;
+			}
+			else return 0x355;
+		}
+	}
+
+	Result applyPatch(uint8_t* buffer, size_t filesize, uint8_t FPS) {
+		FPS -= 15;
+		FPS /= 5;
+		FPS *= 4;
+		blockDelayFPS = false;
+		offset = *(uint32_t*)(&buffer[FPS+8]);
+		while(true) {
+			/* OPCODE:
+				0	=	err
+				1	=	write
+				2	=	compare
+				3	=	block
+				-1	=	endExecution
+			*/
+			int8_t OPCODE = read8(buffer);
+			if (OPCODE == 1) {
+				uint8_t offsets_count = read8(buffer);
+				int64_t address = getAddress(buffer, offsets_count);
+				if (address < 0) 
+					return 6;
+				/* value_type:
+					1		=	uint8
+					2		=	uin16
+					4		=	uint32
+					8		=	uint64
+					0x11	=	int8
+					0x12	=	in16
+					0x14	=	int32
+					0x18	=	int64
+					0x24	=	float
+					0x28	=	double
+				*/
+				uint8_t value_type = read8(buffer);
+				uint8_t loops = read8(buffer);
+				switch(value_type) {
+					case 1:
+					case 0x11: {
+						for (uint8_t i = 0; i < loops; i++) {
+							*(uint8_t*)address = read8(buffer);
+							address += 1;
+						}
+						break;
+					}
+					case 2:
+					case 0x12: {
+						for (uint8_t i = 0; i < loops; i++) {
+							*(uint16_t*)address = read16(buffer);
+							address += 2;
+						}
+						break;
+					}
+					case 4:
+					case 0x14:
+					case 0x24: {
+						for (uint8_t i = 0; i < loops; i++) {
+							*(uint32_t*)address = read32(buffer);
+							address += 4;
+						}
+						break;
+					}
+					case 8:
+					case 0x18:
+					case 0x28: {
+						for (uint8_t i = 0; i < loops; i++) {
+							*(uint64_t*)address = read64(buffer);
+							address += 8;
+						}
+						break;
+					}
+					default:
+						return 3;
+				}
+			}
+			else if (OPCODE == 2) {
+				uint8_t offsets_count = read8(buffer);
+				int64_t address = getAddress(buffer, offsets_count);
+				if (address < 0) 
+					return 6;
+
+				/* compare_type:
+					1	=	>
+					2	=	>=
+					3	=	<
+					4	=	<=
+					5	=	==
+					6	=	!=
+				*/
+				uint8_t compare_type = read8(buffer);
+				uint8_t value_type = read8(buffer);
+				bool passed = false;
+				switch(value_type) {
+					case 1: {
+						uint8_t uint8_compare = *(uint8_t*)address;
+						uint8_t uint8_tocompare = read8(buffer);
+						passed = compareValues(uint8_compare, uint8_tocompare, compare_type);
+						break;
+					}
+					case 2: {
+						uint16_t uint16_compare = *(uint16_t*)address;
+						uint16_t uint16_tocompare = read16(buffer);
+						passed = compareValues(uint16_compare, uint16_tocompare, compare_type);
+						break;
+					}
+					case 4: {
+						uint32_t uint32_compare = *(uint32_t*)address;
+						uint32_t uint32_tocompare = read32(buffer);
+						passed = compareValues(uint32_compare, uint32_tocompare, compare_type);
+						break;
+					}
+					case 8: {
+						uint64_t uint64_compare = *(uint64_t*)address;
+						uint64_t uint64_tocompare = read64(buffer);
+						passed = compareValues(uint64_compare, uint64_tocompare, compare_type);
+						break;
+					}
+					case 0x11: {
+						int8_t int8_compare = *(int8_t*)address;
+						int8_t int8_tocompare = (int8_t)read8(buffer);
+						passed = compareValues(int8_compare, int8_tocompare, compare_type);
+						break;
+					}
+					case 0x12: {
+						int16_t int16_compare = *(int16_t*)address;
+						int16_t int16_tocompare = (int16_t)read16(buffer);
+						passed = compareValues(int16_compare, int16_tocompare, compare_type);
+						break;
+					}
+					case 0x14: {
+						int32_t int32_compare = *(int32_t*)address;
+						int32_t int32_tocompare = (int32_t)read32(buffer);
+						passed = compareValues(int32_compare, int32_tocompare, compare_type);
+						break;
+					}
+					case 0x18: {
+						int64_t int64_compare = *(int64_t*)address;
+						int64_t int64_tocompare = (int64_t)read64(buffer);
+						passed = compareValues(int64_compare, int64_tocompare, compare_type);
+						break;
+					}
+					case 0x24: {
+						float float_compare = *(float*)address;
+						float float_tocompare = readFloat(buffer);
+						passed = compareValues(float_compare, float_tocompare, compare_type);
+						break;
+					}
+					case 0x28: {
+						double double_compare = *(double*)address;
+						double double_tocompare = readDouble(buffer);
+						passed = compareValues(double_compare, double_tocompare, compare_type);
+						break;
+					}
+					default:
+						return 3;
+				}
+
+				offsets_count = read8(buffer);
+				address = getAddress(buffer, offsets_count);
+				if (address < 0) 
+					return 6;
+				value_type = read8(buffer);
+				uint8_t loops = read8(buffer);
+				switch(value_type) {
+					case 1:
+					case 0x11: {
+						for (uint8_t i = 0; i < loops; i++) {
+							uint8_t value8 = read8(buffer);
+							if (passed) writeValue(value8, address);
+							address += 1;
+						}
+						break;
+					}
+					case 2:
+					case 0x12: {
+						for (uint8_t i = 0; i < loops; i++) {
+							uint16_t value16 = read16(buffer);
+							if (passed) writeValue(value16, address);
+							address += 2;
+						}
+						break;
+					}
+					case 4:
+					case 0x14:
+					case 0x24: {
+						for (uint8_t i = 0; i < loops; i++) {
+							uint32_t value32 = read32(buffer);
+							if (passed) writeValue(value32, address);
+							address += 4;
+						}
+						break;
+					}
+					case 8:
+					case 0x18:
+					case 0x28: {
+						for (uint8_t i = 0; i < loops; i++) {
+							uint64_t value64 = read64(buffer);
+							if (passed) writeValue(value64, address);
+							address += 8;
+						}
+						break;
+					}
+					default:
+						return 3;
+				}
+			}
+			else if (OPCODE == 3) {
+				switch(read8(buffer)) {
+					case 1:
+						blockDelayFPS = true;
+						break;
+					default: 
+						return 7;
+				}
+			}
+			else if (OPCODE == -1) {
+				return -1;
+			}
+			else return 255;
+		}
+	}
+}

--- a/saltysd_core/source/ltoa.h
+++ b/saltysd_core/source/ltoa.h
@@ -1,0 +1,48 @@
+/*-------------------------------------------------------------------------
+ integer to string conversion
+
+ Written by:   Bela Torok, 1999
+               bela.torok@kssg.ch
+ usage:
+
+ ultoa(unsigned long value, char* string, int radix)
+ ltoa(long value, char* string, int radix)
+
+ value  ->  Number to be converted
+ string ->  Result
+ radix  ->  Base of value (e.g.: 2 for binary, 10 for decimal, 16 for hex)
+---------------------------------------------------------------------------*/
+
+#define NUMBER_OF_DIGITS 32
+
+void ultoa(unsigned long value, char* string, int radix)
+{
+unsigned char index;
+char buffer[NUMBER_OF_DIGITS];  /* space for NUMBER_OF_DIGITS + '\0' */
+
+  index = NUMBER_OF_DIGITS;
+
+  do {
+    buffer[--index] = '0' + (value % radix);
+    if ( buffer[index] > '9') buffer[index] += 'A' - ':'; /* continue with A, B,... */
+    value /= radix;
+  } while (value != 0);
+
+  do {
+    *string++ = buffer[index++];
+  } while ( index < NUMBER_OF_DIGITS );
+
+  *string = 0;  /* string terminator */
+}
+
+void ltoa(long value, char* string, int radix)
+{
+  if (value < 0 && radix == 10) {
+    *string++ = '-';
+    ultoa(-value, string, radix);
+  }
+  else {
+    ultoa(value, string, radix);
+  }
+}
+

--- a/saltysd_core/source/main.c
+++ b/saltysd_core/source/main.c
@@ -1,5 +1,7 @@
 #include <switch_min.h>
 
+#include "NX-FPS.h"
+
 #include <dirent.h>
 #include <switch_min/kernel/ipc.h>
 #include <switch_min/runtime/threadvars.h>
@@ -14,7 +16,7 @@
 
 u32 __nx_applet_type = AppletType_None;
 
-static char g_heap[0x10000];
+static char g_heap[0x20000];
 
 extern void __nx_exit_clear(void* ctx, Handle thread, void* addr);
 extern void elf_trampoline(void* context, Handle thread, void* func);
@@ -50,6 +52,7 @@ void __libnx_init(void* ctx, Handle main_thread, void* saved_lr)
 	vars_mine.tls_tp = (void*)malloc(0x1000);
 	vars_orig = *getThreadVars();
 	*getThreadVars() = vars_mine;
+	virtmemSetup();
 }
 
 void __attribute__((weak)) __libnx_exit(int rc)
@@ -447,6 +450,8 @@ int main(int argc, char *argv[])
 
 	SaltySDCore_PatchSVCs();
 	SaltySDCore_LoadPatches(true);
+
+	NX_FPS();
 	
 	Result exc = SaltySD_Exception();
 	if (exc == 0x0) SaltySDCore_LoadPlugins();

--- a/saltysd_core/source/main.c
+++ b/saltysd_core/source/main.c
@@ -451,6 +451,8 @@ int main(int argc, char *argv[])
 	SaltySDCore_PatchSVCs();
 	SaltySDCore_LoadPatches(true);
 
+	SaltySDCore_fillRoLoadModule();
+	SaltySDCore_ReplaceImport("_ZN2nn2ro10LoadModuleEPNS0_6ModuleEPKvPvmi", (void*)LoadModule);
 	NX_FPS();
 	
 	Result exc = SaltySD_Exception();

--- a/saltysd_core/source/saltysd_dynamic.c
+++ b/saltysd_core/source/saltysd_dynamic.c
@@ -38,7 +38,7 @@ uint32_t num_replaced_symbols = 0;
 uint64_t relasz1 = 0;
 const Elf64_Rela* rela1 = NULL;
 
-uint64_t SaltySDCore_GetSymbolAddr(void* base, char* name)
+uint64_t SaltySDCore_GetSymbolAddr(void* base, const char* name)
 {
 	const Elf64_Dyn* dyn = NULL;
 	const Elf64_Sym* symtab = NULL;
@@ -82,7 +82,7 @@ uint64_t SaltySDCore_GetSymbolAddr(void* base, char* name)
 	return 0;
 }
 
-uint64_t SaltySDCore_FindSymbol(char* name)
+uint64_t SaltySDCore_FindSymbol(const char* name)
 {
 	if (!elfs) return 0;
 
@@ -95,7 +95,7 @@ uint64_t SaltySDCore_FindSymbol(char* name)
 	return 0;
 }
 
-uint64_t SaltySDCore_FindSymbolBuiltin(char* name)
+uint64_t SaltySDCore_FindSymbolBuiltin(const char* name)
 {
 	if (!builtin_elfs) return 0;
 
@@ -200,7 +200,7 @@ void SaltySDCore_ReplaceModuleImport(void* base, const char* name, void* newfunc
 	}
 }
 
-void SaltySDCore_ReplaceImport(char* name, void* newfunc)
+void SaltySDCore_ReplaceImport(const char* name, void* newfunc)
 {
 	if (!builtin_elfs) return;
 

--- a/saltysd_core/source/saltysd_dynamic.c
+++ b/saltysd_core/source/saltysd_dynamic.c
@@ -24,6 +24,17 @@ struct mod0_header
 	uint32_t dynamic;
 };
 
+struct ReplacedSymbol
+{
+	void* address;
+	const char* name;
+};
+
+uint64_t roLoadModule = 0;
+
+struct ReplacedSymbol* replaced_symbols = NULL;
+uint32_t num_replaced_symbols = 0;
+
 uint64_t relasz1 = 0;
 const Elf64_Rela* rela1 = NULL;
 
@@ -109,7 +120,7 @@ void SaltySDCore_RegisterBuiltinModule(void* base)
 	builtin_elfs[num_builtin_elfs-1] = base;
 }
 
-void SaltySDCore_ReplaceModuleImport(void* base, char* name, void* newfunc)
+void SaltySDCore_ReplaceModuleImport(void* base, const char* name, void* newfunc, bool update)
 {
 	const Elf64_Dyn* dyn = NULL;
 	const Elf64_Rela* rela = NULL;
@@ -150,6 +161,20 @@ void SaltySDCore_ReplaceModuleImport(void* base, char* name, void* newfunc)
 	
 	uint64_t numsyms = ((void*)strtab - (void*)symtab) / sizeof(Elf64_Sym);
 
+	if (!update) {
+		bool detected = false;
+		for (int i = 0; i < num_replaced_symbols; i++) {
+			if (!strcmp(name, replaced_symbols[i].name)) {
+				detected = true;
+			}
+		}
+		if (!detected) {
+			replaced_symbols = realloc(replaced_symbols, ++num_replaced_symbols * sizeof(struct ReplacedSymbol));
+			replaced_symbols[num_replaced_symbols-1].address = newfunc;
+			replaced_symbols[num_replaced_symbols-1].name = name;
+		}
+	}
+
 	int rela_idx = 0;
 	for (; relasz--; rela++, rela_idx++)
 	{
@@ -162,11 +187,16 @@ void SaltySDCore_ReplaceModuleImport(void* base, char* name, void* newfunc)
 		if (strcmp(name, rel_name)) continue;
 		
 		SaltySDCore_printf("SaltySD Core: %x %s to %p, %llx %p\n", rela_idx, rel_name, newfunc, rela->r_offset, base + rela->r_offset);
+		
+		if (!update) {
+			Elf64_Rela replacement = *rela;
+			replacement.r_addend = rela->r_addend + (uint64_t)newfunc - SaltySDCore_FindSymbolBuiltin(rel_name);
 
-		Elf64_Rela replacement = *rela;
-		replacement.r_addend = rela->r_addend + (uint64_t)newfunc - SaltySDCore_FindSymbolBuiltin(rel_name);
-
-		SaltySD_Memcpy((u64)rela, (u64)&replacement, sizeof(Elf64_Rela));
+			SaltySD_Memcpy((u64)rela, (u64)&replacement, sizeof(Elf64_Rela));
+		}
+		else {
+			*(void**)(base + rela->r_offset) = newfunc;
+		}
 	}
 }
 
@@ -176,7 +206,7 @@ void SaltySDCore_ReplaceImport(char* name, void* newfunc)
 
 	for (int i = 0; i < num_builtin_elfs; i++)
 	{
-		SaltySDCore_ReplaceModuleImport(builtin_elfs[i], name, newfunc);
+		SaltySDCore_ReplaceModuleImport(builtin_elfs[i], name, newfunc, false);
 	}
 }
 
@@ -249,4 +279,36 @@ void SaltySDCore_DynamicLinkModule(void* base)
 			}
 		}
 	}
+}
+
+struct Object {
+	void* next;
+	void* prev;
+	void* rela_or_rel_plt;
+	void* rela_or_rel;
+	void* module_base;
+};
+
+struct Module {
+	struct Object* ModuleObject;
+};
+
+void SaltySDCore_fillRoLoadModule() {
+	roLoadModule = SaltySDCore_FindSymbolBuiltin("_ZN2nn2ro10LoadModuleEPNS0_6ModuleEPKvPvmi");
+	return;
+}
+
+typedef Result (*_ZN2nn2ro10LoadModuleEPNS0_6ModuleEPKvPvmi)(struct Module* pOutModule, const void* pImage, void* buffer, size_t bufferSize, int flag);
+Result LoadModule(struct Module* pOutModule, const void* pImage, void* buffer, size_t bufferSize, int flag) {
+	static void* lastModule = 0;
+	if (flag)
+		flag = 0;
+	Result ret = ((_ZN2nn2ro10LoadModuleEPNS0_6ModuleEPKvPvmi)(roLoadModule))(pOutModule, pImage, buffer, bufferSize, flag);
+	if (R_SUCCEEDED(ret) && lastModule != pOutModule) {
+		lastModule = pOutModule;
+		for (int x = 0; x < num_replaced_symbols; x++) {
+			SaltySDCore_ReplaceModuleImport(pOutModule->ModuleObject->module_base, replaced_symbols[x].name, replaced_symbols[x].address, true);
+		}
+	}
+	return ret;
 }

--- a/saltysd_core/source/saltysd_dynamic.c
+++ b/saltysd_core/source/saltysd_dynamic.c
@@ -33,7 +33,7 @@ struct ReplacedSymbol
 uint64_t roLoadModule = 0;
 
 struct ReplacedSymbol* replaced_symbols = NULL;
-uint32_t num_replaced_symbols = 0;
+int32_t num_replaced_symbols = 0;
 
 uint64_t relasz1 = 0;
 const Elf64_Rela* rela1 = NULL;
@@ -172,6 +172,9 @@ void SaltySDCore_ReplaceModuleImport(void* base, const char* name, void* newfunc
 			replaced_symbols = realloc(replaced_symbols, ++num_replaced_symbols * sizeof(struct ReplacedSymbol));
 			replaced_symbols[num_replaced_symbols-1].address = newfunc;
 			replaced_symbols[num_replaced_symbols-1].name = name;
+		}
+		else {
+			newfunc = replaced_symbols[num_replaced_symbols-1].address;
 		}
 	}
 

--- a/saltysd_core/source/saltysd_dynamic.h
+++ b/saltysd_core/source/saltysd_dynamic.h
@@ -12,15 +12,6 @@ extern "C" {
 
 struct Module {
 	void* ModuleObject;
-	u32 State;
-	void* NroPtr;
-	void* BssPtr;
-	void* _x20;
-	void* SourceBuffer;
-	char Name[256]; /* Created by retype action */
-	u8 _x130;
-	u8 _x131;
-	bool isLoaded;  // bool
 };
 
 extern void SaltySDCore_fillRoLoadModule() LINKABLE;

--- a/saltysd_core/source/saltysd_dynamic.h
+++ b/saltysd_core/source/saltysd_dynamic.h
@@ -16,14 +16,14 @@ struct Module {
 
 extern void SaltySDCore_fillRoLoadModule() LINKABLE;
 extern Result LoadModule(struct Module* pOutModule, const void* pImage, void* buffer, size_t bufferSize, int flag) LINKABLE;
-extern uint64_t SaltySDCore_GetSymbolAddr(void* base, char* name) LINKABLE;
-extern uint64_t SaltySDCore_FindSymbol(char* name) LINKABLE;
-extern uint64_t SaltySDCore_FindSymbolBuiltin(char* name) LINKABLE;
+extern uint64_t SaltySDCore_GetSymbolAddr(void* base, const char* name) LINKABLE;
+extern uint64_t SaltySDCore_FindSymbol(const char* name) LINKABLE;
+extern uint64_t SaltySDCore_FindSymbolBuiltin(const char* name) LINKABLE;
 extern void SaltySDCore_RegisterModule(void* base) LINKABLE;
 extern void SaltySDCore_RegisterBuiltinModule(void* base) LINKABLE;
 extern void SaltySDCore_DynamicLinkModule(void* base) LINKABLE;
 extern void SaltySDCore_ReplaceModuleImport(void* base, const char* name, void* newfunc, bool update) LINKABLE;
-extern void SaltySDCore_ReplaceImport(char* name, void* newfunc) LINKABLE;
+extern void SaltySDCore_ReplaceImport(const char* name, void* newfunc) LINKABLE;
 
 #ifdef __cplusplus
 }

--- a/saltysd_core/source/saltysd_dynamic.h
+++ b/saltysd_core/source/saltysd_dynamic.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef SALTYSD_DYNAMIC_H
 #define SALTYSD_DYNAMIC_H
 
@@ -9,13 +10,28 @@
 extern "C" {
 #endif
 
+struct Module {
+	void* ModuleObject;
+	u32 State;
+	void* NroPtr;
+	void* BssPtr;
+	void* _x20;
+	void* SourceBuffer;
+	char Name[256]; /* Created by retype action */
+	u8 _x130;
+	u8 _x131;
+	bool isLoaded;  // bool
+};
+
+extern void SaltySDCore_fillRoLoadModule() LINKABLE;
+extern Result LoadModule(struct Module* pOutModule, const void* pImage, void* buffer, size_t bufferSize, int flag) LINKABLE;
 extern uint64_t SaltySDCore_GetSymbolAddr(void* base, char* name) LINKABLE;
 extern uint64_t SaltySDCore_FindSymbol(char* name) LINKABLE;
 extern uint64_t SaltySDCore_FindSymbolBuiltin(char* name) LINKABLE;
 extern void SaltySDCore_RegisterModule(void* base) LINKABLE;
 extern void SaltySDCore_RegisterBuiltinModule(void* base) LINKABLE;
 extern void SaltySDCore_DynamicLinkModule(void* base) LINKABLE;
-extern void SaltySDCore_ReplaceModuleImport(void* base, char* name, void* newfunc) LINKABLE;
+extern void SaltySDCore_ReplaceModuleImport(void* base, const char* name, void* newfunc, bool update) LINKABLE;
 extern void SaltySDCore_ReplaceImport(char* name, void* newfunc) LINKABLE;
 
 #ifdef __cplusplus


### PR DESCRIPTION
- Integrate NX-FPS and ReverseNX-RT code to SaltyNX Core for increased compability with games. If any plugin will try to replace symbol that is used already by NX-FPS or ReverseNX-RT, plugins will have priority. 
- Now Core also replaces import for nn::ro::LoadModule to detect if NRO was loaded, Core caches all import replacements and reapplies them for each new NRO. This solves compability issues with FC 24, Final Fantasy VIII, Final Fantasy X and other games that implemented functions used by plugins into NRO. 