### PR TITLE
Allow creating third buffer

### DIFF
--- a/saltysd_core/source/NX-FPS.cpp
+++ b/saltysd_core/source/NX-FPS.cpp
@@ -35,13 +35,6 @@ struct NVNMemoryPoolBuilder {
 	char reserved[0x40];
 };
 
-struct NVNRectangle {
-	int height;
-	int width;
-	int x;
-	int y;
-};
-
 typedef int NVNtextureFlags;
 typedef int NVNtextureTarget;
 typedef int NVNformat;

--- a/saltysd_core/source/NX-FPS.cpp
+++ b/saltysd_core/source/NX-FPS.cpp
@@ -582,7 +582,7 @@ void nvnCommandBufferCopyTextureToTexture(const void* nvnCommandBuffer, const NV
 
 void nvnCommandBufferSetRenderTargets(const void* nvnCommandBuffer, int numBufferedFrames, NVNTexture** nvnTextures, void* unk1, NVNTexture* nvnDepthTexture, void* unk2) {
 	if (isDoubleBuffer) {
-        if (numBufferedFrames == 1 && nvnTextures[0] == orig_nvnTextures) { 
+        if (numBufferedFrames == 1 && nvnTextures[0] == orig_nvnTexture) { 
             nvnTextures = &Frame_buffers[2];
         }
 		else if (nvnTextures[0] == Frame_buffers[0]) {

--- a/saltysd_core/source/NX-FPS.cpp
+++ b/saltysd_core/source/NX-FPS.cpp
@@ -594,12 +594,7 @@ void nvnCommandBufferSetRenderTargets(const void* nvnCommandBuffer, int numBuffe
 }
 
 void nvnWindowBuilderSetTextures(const nvnWindowBuilder* nvnWindowBuilder, int numBufferedFrames, NVNTexture** nvnTextures) {
-	*(Shared.Buffers) = numBufferedFrames;
-	if (*(Shared.SetBuffers) >= 2 && *(Shared.SetBuffers) <= numBufferedFrames) {
-		numBufferedFrames = *(Shared.SetBuffers);
-	}
-	*(Shared.ActiveBuffers) = numBufferedFrames;
-	if (numBufferedFrames == 2) {
+	if (numBufferedFrames == 2 && *(Shared.SetBuffers) == 3) {
 		isDoubleBuffer = true;
 		//Copying overflowed pointer
 		orig_nvnTexture = nvnTextures[2];
@@ -647,7 +642,16 @@ void nvnWindowBuilderSetTextures(const nvnWindowBuilder* nvnWindowBuilder, int n
 		Frame_buffers[2] = &m_ThirdBuffer;
 		nvnTextures = Frame_buffers;
 		numBufferedFrames = 3;
+		*(Shared.Buffers) = 3;
+		*(Shared.ActiveBuffers) = 3;
+		*(Shared.SetActiveBuffers) = 2;
+
 	}
+	else if (*(Shared.SetBuffers) >= 2 && *(Shared.SetBuffers) <= numBufferedFrames) {
+		numBufferedFrames = *(Shared.SetBuffers);
+	}
+	*(Shared.Buffers) = numBufferedFrames;
+	*(Shared.ActiveBuffers) = numBufferedFrames;
 	return ((nvnBuilderSetTextures_0)(Ptrs.nvnWindowBuilderSetTextures))(nvnWindowBuilder, numBufferedFrames, nvnTextures);
 }
 

--- a/saltysd_core/source/NX-FPS.cpp
+++ b/saltysd_core/source/NX-FPS.cpp
@@ -570,34 +570,28 @@ uintptr_t eglGetProc(const char* eglName) {
 	return ((eglGetProcAddress_0)(Address_weaks.eglGetProcAddress))(eglName);
 }
 
-NVNTexture* orig_nvnTexture = 0;
+NVNTexture** orig_nvnTextures = 0;
 bool isDoubleBuffer = false;
-int texture_index = 0;
+int texture_index = -1;
 void nvnCommandBufferCopyTextureToTexture(const void* nvnCommandBuffer, const NVNTexture* nvnTextureSrc, void* unk1, void* unk2, NVNTexture* nvnTextureDst, void* unk3, void* unk4) {
-	if (isDoubleBuffer && nvnTextureDst == orig_nvnTexture) {
-		nvnTextureDst = Frame_buffers[2];
+	if (isDoubleBuffer) {
+		nvnTextureDst = Frame_buffers[texture_index];
 	}
 	return ((nvnCommandBufferCopyTextureToTexture_0)(Ptrs.nvnCommandBufferCopyTextureToTexture))(nvnCommandBuffer, nvnTextureSrc, unk1, unk2, nvnTextureDst, unk3, unk4);
 }
 
 void nvnCommandBufferSetRenderTargets(const void* nvnCommandBuffer, int numBufferedFrames, NVNTexture** nvnTextures, void* unk1, NVNTexture* nvnDepthTexture, void* unk2) {
 	if (isDoubleBuffer) {
-        if (numBufferedFrames == 1 && nvnTextures[0] == orig_nvnTexture) { 
-            nvnTextures = &Frame_buffers[2];
-        }
-		else if (nvnTextures[0] == Frame_buffers[0]) {
-			nvnTextures = Frame_buffers;
-			numBufferedFrames = 3;
-		}
+		if (nvnTextures[0] == orig_nvnTextures[2])
+			nvnTextures[0] = Frame_buffers[2];
 	}
 	return ((nvnCommandBufferSetRenderTargets_0)(Ptrs.nvnCommandBufferSetRenderTargets))(nvnCommandBuffer, numBufferedFrames, nvnTextures, unk1, nvnDepthTexture, unk2);
 }
 
 void nvnWindowBuilderSetTextures(const nvnWindowBuilder* nvnWindowBuilder, int numBufferedFrames, NVNTexture** nvnTextures) {
-	if (numBufferedFrames == 2 && *(Shared.SetBuffers) == 3) {
+	if (numBufferedFrames == 2 /*&& *(Shared.SetBuffers) == 3*/) {
 		isDoubleBuffer = true;
-		//Copying overflowed pointer
-		orig_nvnTexture = nvnTextures[2];
+		orig_nvnTextures = nvnTextures;
 		static bool initialized = false;
 		static void* buffer = 0;
 

--- a/saltysd_core/source/NX-FPS.cpp
+++ b/saltysd_core/source/NX-FPS.cpp
@@ -574,11 +574,25 @@ uintptr_t eglGetProc(const char* eglName) {
 	return ((eglGetProcAddress_0)(Address_weaks.eglGetProcAddress))(eglName);
 }
 
-void nvnCommandBufferSetRenderTargets(const void* nvnCommandBuffer, int numBufferedFrames, NVNTexture** nvnTextures, void* unk1, NVNTexture* nvnDepthTexture, void* unk2) {
+NVNTexture** orig_nvnTextures = 0;
+int numBufferedFrames_orig = 0;
 
-	if (numBufferedFrames == 3) {
-		nvnTextures = &Frame_buffers[0];
-		numBufferedFrames = 3;
+void nvnCommandBufferSetRenderTargets(const void* nvnCommandBuffer, int numBufferedFrames, NVNTexture** nvnTextures, void* unk1, NVNTexture* nvnDepthTexture, void* unk2) {
+	if (numBufferedFrames_orig == 2) {
+		if (numBufferedFrames == 1) { 
+			int index = 0;
+			while (index < numBufferedFrames_orig) {
+				if (nvnTextures[0] == orig_nvnTextures[index]) {
+					nvnTextures = &Frame_buffers[index];
+					break;
+				}
+				index++;
+			}
+		}
+		else if (nvnTextures[0] == Frame_buffers[0]) {
+			nvnTextures = Frame_buffers;
+			numBufferedFrames = 3;
+		}
 	}
 	return ((nvnCommandBufferSetRenderTargets_0)(Ptrs.nvnCommandBufferSetRenderTargets))(nvnCommandBuffer, numBufferedFrames, nvnTextures, unk1, nvnDepthTexture, unk2);
 }
@@ -589,7 +603,9 @@ void nvnWindowBuilderSetTextures(const nvnWindowBuilder* nvnWindowBuilder, int n
 		numBufferedFrames = *(Shared.SetBuffers);
 	}
 	*(Shared.ActiveBuffers) = numBufferedFrames;
-	if (numBufferedFrames == 3) {
+	orig_nvnTextures = nvnTextures;
+	if (numBufferedFrames == 2) {
+		numBufferedFrames_orig = 2;
 		static bool initialized = false;
 		static void* buffer = 0;
 
@@ -632,7 +648,7 @@ void nvnWindowBuilderSetTextures(const nvnWindowBuilder* nvnWindowBuilder, int n
 		Frame_buffers[0] = nvnTextures[0];
 		Frame_buffers[1] = nvnTextures[1];
 		Frame_buffers[2] = &m_ThirdBuffer;
-		nvnTextures = &Frame_buffers[0];
+		nvnTextures = Frame_buffers;
 		numBufferedFrames = 3;
 	}
 	return ((nvnBuilderSetTextures_0)(Ptrs.nvnWindowBuilderSetTextures))(nvnWindowBuilder, numBufferedFrames, nvnTextures);


### PR DESCRIPTION
It was tested only on triple buffer games by replacing third buffer. Double buffer games will require different approach since we will be getting pointer from overflowed array. So this must wait until I will be able to get double buffer game in my hands.