### PR TITLE
Reduce sysmodule footprint, fix support with Card-en-Ciel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ saltysd_bootstrap/saltysd_bootstrap.elf:
 saltysd_core/saltysd_core.elf: libnx_min/nx/lib/libnx_min.a
 	@cd saltysd_core && make
 
-saltysd_proc/data/saltysd_bootstrap.elf: saltysd_bootstrap/saltysd_bootstrap.elf
-	@mkdir -p saltysd_proc/data/
+sdcard_out/SaltySD/saltysd_bootstrap.elf: saltysd_bootstrap/saltysd_bootstrap.elf
+	@mkdir -p sdcard_out/SaltySD/
 	@cp $< $@
 
 sdcard_out/SaltySD/saltysd_core.elf: saltysd_core/saltysd_core.elf

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: libnx_min/nx/lib/libnx_min.a sdcard_out/SaltySD/saltysd_core.elf sdcard_out
 libnx_min/nx/lib/libnx_min.a:
 	@cd libnx_min && make
 
-saltysd_proc/saltysd_proc.nsp: saltysd_proc/data/saltysd_bootstrap.elf
+saltysd_proc/saltysd_proc.nsp: saltysd_bootstrap/saltysd_bootstrap.elf
 	@cd saltysd_proc && make
 
 saltysd_bootstrap/saltysd_bootstrap.elf:
@@ -40,6 +40,7 @@ sdcard_out/atmosphere/contents/0000000000534C56/exefs.nsp: saltysd_proc/saltysd_
 	@touch sdcard_out/SaltySD/flags/log.flag
 	@cp exceptions.txt sdcard_out/SaltySD/exceptions.txt
 	@cp toolbox.json sdcard_out/atmosphere/contents/0000000000534C56/toolbox.json
+	@cp saltysd_bootstrap/saltysd_bootstrap.elf sdcard_out/SaltySD/saltysd_bootstrap.elf
 
 
 clean:

--- a/saltysd_core/source/ReverseNX.cpp
+++ b/saltysd_core/source/ReverseNX.cpp
@@ -17,6 +17,7 @@ extern "C" {
 	typedef void (*_ZN2nn2oe27GetDefaultDisplayResolutionEPiS1_)(int* width, int* height);
 	typedef void (*_ZN2nn2oe38GetDefaultDisplayResolutionChangeEventEPNS_2os11SystemEventE)(SystemEvent* systemEvent);
 	typedef bool (*nnosTryWaitSystemEvent)(SystemEvent* systemEvent);
+	typedef void (*nnosWaitSystemEvent)(SystemEvent* systemEvent);
 	typedef SystemEvent* (*_ZN2nn2oe27GetNotificationMessageEventEv)();
 	typedef void (*nnosInitializeMultiWaitHolderForSystemEvent)(void* MultiWaitHolderType, SystemEvent* systemEvent);
 	typedef void (*nnosLinkMultiWaitHolder)(void* MultiWaitType, void* MultiWaitHolderType);
@@ -32,6 +33,7 @@ struct {
 	uintptr_t GetDefaultDisplayResolution;
 	uintptr_t GetDefaultDisplayResolutionChangeEvent;
 	uintptr_t TryWaitSystemEvent;
+	uintptr_t WaitSystemEvent;
 	uintptr_t GetNotificationMessageEvent;
 	uintptr_t InitializeMultiWaitHolderForSystemEvent;
 	uintptr_t LinkMultiWaitHolder;
@@ -175,6 +177,19 @@ bool TryWaitSystemEvent(SystemEvent* systemEvent) {
 	return ((nnosTryWaitSystemEvent)(Address_weaks.TryWaitSystemEvent))(systemEvent);
 }
 
+void WaitSystemEvent(SystemEvent* systemEvent) {
+	if (systemEvent == defaultDisplayResolutionChangeEventCopy) {
+		*pluginActive_shared = true;
+		while(true) {
+			bool return_now = TryWaitSystemEvent(systemEvent);
+			if (return_now)
+				return;
+			svcSleepThread(1'000'000);
+		}
+	}
+	return ((nnosWaitSystemEvent)(Address_weaks.WaitSystemEvent))(systemEvent);
+}
+
 /* 
 	Used by Monster Hunter Rise.
 
@@ -234,6 +249,7 @@ extern "C" {
 			Address_weaks.GetDefaultDisplayResolution = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe27GetDefaultDisplayResolutionEPiS1_");
 			Address_weaks.GetDefaultDisplayResolutionChangeEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe38GetDefaultDisplayResolutionChangeEventEPNS_2os11SystemEventE");
 			Address_weaks.TryWaitSystemEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os18TryWaitSystemEventEPNS0_15SystemEventTypeE");
+			Address_weaks.WaitSystemEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os15WaitSystemEventEPNS0_15SystemEventTypeE");
 			Address_weaks.GetNotificationMessageEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe27GetNotificationMessageEventEv");
 			Address_weaks.InitializeMultiWaitHolderForSystemEvent = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os25InitializeMultiWaitHolderEPNS0_19MultiWaitHolderTypeEPNS0_15SystemEventTypeE");
 			Address_weaks.LinkMultiWaitHolder = SaltySDCore_FindSymbolBuiltin("_ZN2nn2os19LinkMultiWaitHolderEPNS0_13MultiWaitTypeEPNS0_19MultiWaitHolderTypeE");
@@ -246,6 +262,7 @@ extern "C" {
 			SaltySDCore_ReplaceImport("_ZN2nn2oe27GetDefaultDisplayResolutionEPiS1_", (void*)GetDefaultDisplayResolution);
 			SaltySDCore_ReplaceImport("_ZN2nn2oe38GetDefaultDisplayResolutionChangeEventEPNS_2os11SystemEventE", (void*)GetDefaultDisplayResolutionChangeEvent);
 			SaltySDCore_ReplaceImport("_ZN2nn2os18TryWaitSystemEventEPNS0_15SystemEventTypeE", (void*)TryWaitSystemEvent);
+			SaltySDCore_ReplaceImport("_ZN2nn2os15WaitSystemEventEPNS0_15SystemEventTypeE", (void*)WaitSystemEvent);
 			SaltySDCore_ReplaceImport("_ZN2nn2oe27GetNotificationMessageEventEv", (void*)GetNotificationMessageEvent);
 			SaltySDCore_ReplaceImport("_ZN2nn2os25InitializeMultiWaitHolderEPNS0_19MultiWaitHolderTypeEPNS0_15SystemEventTypeE", (void*)InitializeMultiWaitHolder);
 			SaltySDCore_ReplaceImport("_ZN2nn2os19LinkMultiWaitHolderEPNS0_13MultiWaitTypeEPNS0_19MultiWaitHolderTypeE", (void*)LinkMultiWaitHolder);

--- a/saltysd_proc/Makefile
+++ b/saltysd_proc/Makefile
@@ -39,9 +39,9 @@ EXEFS_SRC	:=	exefs_src
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -s
+ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
-CFLAGS	:=	-g -Wall -O3 \
+CFLAGS	:=	-g -Wall -Os \
 			-ffast-math \
 			$(ARCH) $(DEFINES)
 

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -20,7 +20,7 @@ u32 __nx_applet_type = AppletType_None;
 void serviceThread(void* buf);
 
 Handle saltyport, sdcard, injectserv;
-static char g_heap[0x80000];
+static char g_heap[0x70000];
 bool should_terminate = false;
 bool already_hijacking = false;
 DebugEventInfo eventinfo;
@@ -158,10 +158,10 @@ bool isCheatsFolderInstalled() {
 }
 
 void renameCheatsFolder() {
-    char cheatspath[0x40] = "";
+    char cheatspath[0x3C] = "";
     char cheatspathtemp[0x40] = "";
 
-    snprintf(cheatspath, 0x40, "sdmc:/atmosphere/contents/%016lx/cheats", TIDnow);
+    snprintf(cheatspath, 0x3C, "sdmc:/atmosphere/contents/%016lx/cheats", TIDnow);
     snprintf(cheatspathtemp, 0x40, "%stemp", cheatspath);
     if (!check) {
         rename(cheatspath, cheatspathtemp);

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -6,7 +6,6 @@
 #include <dirent.h>
 #include <switch_min/kernel/svc_extra.h>
 #include <switch_min/kernel/ipc.h>
-#include "saltysd_bootstrap_elf.h"
 
 #include "spawner_ipc.h"
 
@@ -21,7 +20,7 @@ u32 __nx_applet_type = AppletType_None;
 void serviceThread(void* buf);
 
 Handle saltyport, sdcard, injectserv;
-static char g_heap[0xA0000];
+static char g_heap[0x80000];
 bool should_terminate = false;
 bool already_hijacking = false;
 DebugEventInfo eventinfo;
@@ -209,8 +208,18 @@ void hijack_bootstrap(Handle* debug, u64 pid, u64 tid)
     
     // Load in the ELF
     //svcReadDebugProcessMemory(backup, debug, context.pc.x, 0x1000);
+    FILE* file = fopen("sdmc:/SaltySD/saltysd_bootstrap.elf", "rb");
+    if (!file) {
+        SaltySD_printf("SaltySD: SaltySD/saltysd_bootstrap.elf not found, aborting...\n", ret);
+        svcCloseHandle(*debug);
+        return;
+    }
+    fseek(file, 0, 2);
+    size_t saltysd_bootstrap_elf_size = ftell(file);
+    fseek(file, 0, 0);
     u8* elf = malloc(saltysd_bootstrap_elf_size);
-    memcpy(elf, saltysd_bootstrap_elf, saltysd_bootstrap_elf_size);
+    fread(elf, saltysd_bootstrap_elf_size, 1, file);
+    fclose(file);
     
     uint64_t new_start;
     load_elf_debug(*debug, &new_start, elf, saltysd_bootstrap_elf_size);


### PR DESCRIPTION
This reduces sysmodule RAM usage from 1.0 MB to 720 kB, so 28% reduction.

It requires saltysd_bootstrap.elf to be copied to SaltySD folder on sdcard.

Also fixes ReverseNX support for Card-en-Ciel 