### PR TITLE
Add support for changing refresh rates in docked mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Remember to restart Switch
 ---
 
 # Thanks to
-- `Cooler3D` for sharing code with me how he was changing display refresh rate in his tools that were first publicly available tools allowing this on HOS. I have used that as basis to make my own function.
+- `Cooler3D` for sharing code with me how he was changing handheld display refresh rate in his tools that were first publicly available tools allowing this on HOS. I have used that as basis to make my own function.
 
 # List of titles not compatible with plugins/patches
 

--- a/libnx_min/nx/switch.specs
+++ b/libnx_min/nx/switch.specs
@@ -1,7 +1,7 @@
 %rename link                old_link
 
 *link:
-%(old_link) -T %:getenv(DEVKITPRO /libnx/switch.ld) -pie --gc-sections -z text -z nodynamic-undefined-weak --build-id=sha1 --nx-module-name
+%(old_link) -T %:getenv(TOPDIR /../libnx_min/nx/switch.ld) -pie --gc-sections -z text -z nodynamic-undefined-weak --build-id=sha1 --nx-module-name
 
 *startfile:
 crti%O%s crtbegin%O%s

--- a/saltysd_core/Makefile
+++ b/saltysd_core/Makefile
@@ -7,7 +7,7 @@ $(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/de
 endif
 
 TOPDIR ?= $(CURDIR)
-include $(DEVKITPRO)/libnx/switch_rules
+include $(TOPDIR)/../libnx_min/nx/switch_rules
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
@@ -51,8 +51,8 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++23
 
 ASFLAGS	     :=	-g $(ARCH)
 
-LDFLAGS				=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-s,--dynamic-list=$(CURDIR)/../dynamic_symbols.txt -Wl,-Map,$(notdir $*.map)
-LDFLAGS_TEST_DEBUG	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH)
+LDFLAGS				=	-specs=$(TOPDIR)/../libnx_min/nx/switch.specs -g $(ARCH) -Wl,-s,--dynamic-list=$(CURDIR)/../dynamic_symbols.txt -Wl,-Map,$(notdir $*.map)
+LDFLAGS_TEST_DEBUG	=	-specs=$(TOPDIR)/../libnx_min/nx/switch.specs -g $(ARCH)
 
 LIBS	:= -lnx_min
 
@@ -60,7 +60,7 @@ LIBS	:= -lnx_min
 # list of directories containing libraries, this must be the top level containing
 # include and lib
 #---------------------------------------------------------------------------------
-LIBDIRS	:= $(PORTLIBS) $(LIBNX) $(CURDIR)/../libnx_min/nx/
+LIBDIRS	:= $(PORTLIBS) $(CURDIR)/../libnx_min/nx/
 
 
 #---------------------------------------------------------------------------------

--- a/saltysd_core/Makefile
+++ b/saltysd_core/Makefile
@@ -31,7 +31,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 TARGET		:=	saltysd_core
 BUILD		:=	build
-SOURCES		:=	source
+SOURCES		:=	source source/tinyexpr
 DATA		:=	data
 INCLUDES	:=	include
 EXEFS_SRC	:=	exefs_src
@@ -39,7 +39,7 @@ EXEFS_SRC	:=	exefs_src
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -fno-plt
+ARCH	    :=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -fno-plt
 
 CFLAGS	:=	-Wall -O2 \
 			-ffast-math \
@@ -49,8 +49,10 @@ CFLAGS	+=	$(INCLUDE) -DSWITCH
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++23
 
-ASFLAGS	:=	-g $(ARCH)
-LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-s,--dynamic-list=$(CURDIR)/../dynamic_symbols.txt -Wl,-Map,$(notdir $*.map)
+ASFLAGS	     :=	-g $(ARCH)
+
+LDFLAGS				=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-s,--dynamic-list=$(CURDIR)/../dynamic_symbols.txt -Wl,-Map,$(notdir $*.map)
+LDFLAGS_TEST_DEBUG	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH)
 
 LIBS	:= -lnx_min
 
@@ -98,6 +100,8 @@ endif
 export OFILES	:=	$(addsuffix .o,$(BINFILES)) \
 			$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
 
+export OFILES2	:=	$(foreach file,$(OFILES),$(BUILD)/$(file))
+
 export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 			-I$(CURDIR)/$(BUILD)
@@ -139,11 +143,12 @@ all: $(BUILD)
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@$(LD) $(LDFLAGS_TEST_DEBUG) $(OFILES2) $(LIBPATHS) $(LIBS) -o $(TARGET)-debug.elf
 
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(TARGET).pfs0 $(TARGET).nso $(TARGET).nro $(TARGET).nsp $(TARGET).nacp $(TARGET).elf
+	@rm -fr $(BUILD) $(TARGET).pfs0 $(TARGET).nso $(TARGET).nro $(TARGET).nsp $(TARGET).nacp $(TARGET).elf $(TARGET)-debug.elf
 
 
 #---------------------------------------------------------------------------------

--- a/saltysd_core/source/lock.hpp
+++ b/saltysd_core/source/lock.hpp
@@ -10,6 +10,7 @@ namespace LOCK {
 	bool blockDelayFPS = false;
 	uint8_t gen = 0;
 	bool MasterWriteApplied = false;
+	uint64_t DockedRefreshRateDelay = 4000000000;
 	double overwriteRefreshRate = 0;
 
 	struct {

--- a/saltysd_core32/Makefile
+++ b/saltysd_core32/Makefile
@@ -31,7 +31,7 @@ include $(DEVKITPRO)/devkitARM/base_rules
 #---------------------------------------------------------------------------------
 TARGET		:=	saltysd_core32
 BUILD		:=	build
-SOURCES		:=	source
+SOURCES		:=	source source/tinyexpr
 DATA		:=	data
 INCLUDES	:=	include
 EXEFS_SRC	:=	exefs_src

--- a/saltysd_core32/source/NX-FPS.cpp
+++ b/saltysd_core32/source/NX-FPS.cpp
@@ -173,25 +173,6 @@ struct {
 } Ptrs;
 
 struct {
-	uintptr_t nvnWindowGetProcAddress;
-	uintptr_t nvnQueuePresentTexture;
-	uintptr_t nvnWindowSetPresentInterval;
-	uintptr_t nvnWindowBuilderSetTextures;
-	uintptr_t nvnWindowAcquireTexture;
-	uintptr_t nvnSyncWait;
-	uintptr_t nvnGetProcAddress;
-	uintptr_t nvnWindowSetNumActiveTextures;
-	uintptr_t nvnWindowInitialize;
-	uintptr_t eglGetProcAddress;
-	uintptr_t eglSwapBuffers;
-	uintptr_t eglSwapInterval;
-	uintptr_t nvnCommandBufferSetRenderTargets;
-	uintptr_t nvnCommandBufferSetViewport;
-	uintptr_t nvnCommandBufferSetViewports;
-	uintptr_t nvnCommandBufferSetDepthRange;
-} Address;
-
-struct {
 	uint8_t FPS = 0xFF;
 	float FPSavg = 255;
 	bool FPSmode = 0;
@@ -235,698 +216,492 @@ inline uint32_t getMainAddress() {
 	return 0;
 }
 
-uint32_t vulkanSwap2 (const void* VkQueue_T, const void* VkPresentInfoKHR) {
-	static uint8_t FPS_temp = 0;
-	static uint64_t starttick = 0;
-	static uint64_t endtick = 0;
-	static uint64_t deltatick = 0;
-	static uint64_t frameend = 0;
-	static uint64_t framedelta = 0;
-	static uint64_t frameavg = 0;
-	static uint8_t FPSlock = 0;
-	static uint32_t FPStiming = 0;
-	static uint8_t FPStickItr = 0;
-	static uint8_t range = 0;
-	static uint8_t rangeoverride = 0;
-	
+namespace NX_FPS_Math {
+	uint8_t FPS_temp = 0;
+	uint64_t starttick = 0;
+	uint64_t starttick2 = 0;
+	uint64_t endtick = 0;
+	uint64_t frameend = 0;
+	uint64_t frameavg = 0;
+	uint8_t FPSlock = 0;
+	int32_t FPStiming = 0;
+	uint8_t FPStickItr = 0;
+	uint8_t range = 0;
 	bool FPSlock_delayed = false;
-	
-	if (!starttick) {
-		(Shared -> API) = 3;
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
-	}
+	bool old_force = false;
+	int32_t new_fpslock = 0;
+	u8 OpMode = 0;
 
-	uint32_t FPStimingoverride = 0;
-	if (LOCK::overwriteRefreshRate > 0) {
-		if (LOCK::overwriteRefreshRate >= 60.0) {
-			FPStimingoverride = (uint32_t)((double)systemtickfrequency / LOCK::overwriteRefreshRate) - 8000;
-			FPStimingoverride += 20 * rangeoverride;
+	void PreFrame() {
+		new_fpslock = (LOCK::overwriteRefreshRate ? LOCK::overwriteRefreshRate : (Shared -> FPSlocked));
+		OpMode = ((_ZN2nn2oe16GetOperationModeEv)(Address_weaks.GetOperationMode))();
+		if (old_force != (Shared -> forceOriginalRefreshRate)) {
+			if (OpMode == 1)
+				svcSleepThread(LOCK::DockedRefreshRateDelay);
+			old_force = (Shared -> forceOriginalRefreshRate);
 		}
-		else {
-			FPStimingoverride = (uint32_t)((double)systemtickfrequency / LOCK::overwriteRefreshRate) - 6000;		
-			FPStimingoverride += 20 * rangeoverride;
-		}
-	}
-	
 
-	if ((FPStiming && !LOCK::blockDelayFPS && (!(Shared -> displaySync) || (Shared -> FPSlocked) < (Shared -> displaySync))) || FPStimingoverride) {
-		uint64_t tick = 0;
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
-		if ((tick - frameend) < (FPStimingoverride ? FPStimingoverride : FPStiming)) {
-			FPSlock_delayed = true;
-		}
-		while ((tick - frameend) < (FPStimingoverride ? FPStimingoverride : FPStiming)) {
-			svcSleepThread(-2);
-			svcSleepThread(10000);
+		if ((FPStiming && !LOCK::blockDelayFPS && (!new_fpslock || new_fpslock < (Shared -> displaySync)))) {
+			uint64_t tick = 0;
 			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
-		}
-	}
-
-	uint32_t vulkanResult = ((_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR_0)(Address_weaks.nvSwapchainQueuePresentKHR))(VkQueue_T, VkPresentInfoKHR);
-	((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&endtick);
-	framedelta = endtick - frameend;
-	frameavg = ((9*frameavg) + framedelta) / 10;
-	Stats.FPSavg = systemtickfrequency / (float)frameavg;
-
-	if ((FPSlock_delayed && FPStiming) || FPStimingoverride) {
-		if (Stats.FPSavg > ((float)FPSlock)) {
-			if (range < 200) {
-				FPStiming += 20;
-				range++;
+			if ((int64_t)(tick - frameend) < (FPStiming + (range * 20))) {
+				FPSlock_delayed = true;
 			}
-		}
-		else if ((std::lround(Stats.FPSavg) == FPSlock) && (Stats.FPSavg < (float)FPSlock)) {
-			if (range > 0) {
-				FPStiming -= 20;
-				range--;
-			}
-		}
-		if (Stats.FPSavg > LOCK::overwriteRefreshRate) {
-			if (rangeoverride < 200) {
-				rangeoverride++;
-			}
-		}
-		else if ((std::lround(Stats.FPSavg) == LOCK::overwriteRefreshRate) && (Stats.FPSavg <  LOCK::overwriteRefreshRate)) {
-			if (rangeoverride > 0) {
-				rangeoverride--;
+			while ((int64_t)(tick - frameend) < FPStiming + (range * 20)) {
+				svcSleepThread(-2);
+				svcSleepThread(10000);
+				((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
 			}
 		}
 	}
 
-	frameend = endtick;
-	
-	FPS_temp++;
-	deltatick = endtick - starttick;
+	void PostFrame() {
+		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&endtick);
+		uint64_t framedelta = endtick - frameend;
+		frameavg = ((9*frameavg) + framedelta) / 10;
+		Stats.FPSavg = systemtickfrequency / (float)frameavg;
 
-	Shared -> FPSticks[FPStickItr++] = framedelta;
-	FPStickItr %= 10;
+		if (FPSlock_delayed && FPStiming) {
+			if (Stats.FPSavg > ((float)new_fpslock)) {
+				if (range < 200) {
+					range++;
+				}
+			}
+			else if ((std::lround(Stats.FPSavg) == new_fpslock) && (Stats.FPSavg < (float)new_fpslock)) {
+				if (range > 0) {
+					range--;
+				}
+			}
+		}
 
-	if (deltatick > systemtickfrequency) {
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
-		Stats.FPS = FPS_temp - 1;
-		FPS_temp = 0;
-		(Shared -> FPS) = Stats.FPS;
-		if (changeFPS && !configRC && FPSlock) {
-			LOCK::applyPatch(configBuffer, configSize, FPSlock, (Shared -> displaySync));
-			(Shared -> patchApplied) = 1;
+		frameend = endtick;
+		
+		FPS_temp++;
+		uint64_t deltatick = endtick - starttick;
+		uint64_t deltatick2 = endtick - starttick2;
+
+		Shared -> FPSticks[FPStickItr++] = framedelta;
+		FPStickItr %= 10;
+
+		if (deltatick2 > (systemtickfrequency / ((OpMode == 1) ? 30 : 1))) {
+			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick2);
+			if (!configRC && FPSlock) {
+				LOCK::applyPatch(configBuffer, configSize, FPSlock, (Shared -> displaySync));
+			}
 		}
-		if (((_ZN2nn2oe16GetOperationModeEv)(Address_weaks.GetOperationMode))() == true && (Shared -> displaySync) != 0) {
-			(Shared -> displaySync) = 0;
-			FPSlock = 0;
+
+		if (deltatick > systemtickfrequency) {
+			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
+			Stats.FPS = FPS_temp - 1;
+			FPS_temp = 0;
+			(Shared -> FPS) = Stats.FPS;
+			if (!configRC && FPSlock) {
+				(Shared -> patchApplied) = 1;
+			}
 		}
+
+		(Shared -> FPSavg) = Stats.FPSavg;
+		(Shared -> pluginActive) = true;
 	}
+}
 
-	(Shared -> FPSavg) = Stats.FPSavg;
-	(Shared -> pluginActive) = true;
-
-	if (FPSlock != (Shared -> FPSlocked) || (FPSlock && !FPStiming)) {
-		if (((Shared -> FPSlocked) < 60) && ((Shared -> FPSlocked) > 0)) {
-			FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 6000;
+namespace vk {
+	namespace nvSwapchain { 
+	uint32_t QueuePresent (const void* VkQueue_T, const void* VkPresentInfoKHR) {
+		
+		if (!NX_FPS_Math::starttick) {
+			(Shared -> API) = 3;
+			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&NX_FPS_Math::starttick);
+			NX_FPS_Math::starttick2 = NX_FPS_Math::starttick;
 		}
-		else FPStiming = 0;
-		if ((Shared -> FPSlocked) == 0) 
+		
+		NX_FPS_Math::PreFrame();
+		uint32_t vulkanResult = ((_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR_0)(Address_weaks.nvSwapchainQueuePresentKHR))(VkQueue_T, VkPresentInfoKHR);
+		NX_FPS_Math::PostFrame();
+
+		if ((Shared -> FPSlocked) == 0 && LOCK::overwriteRefreshRate == 0) {
+			NX_FPS_Math::FPStiming = 0;
+			NX_FPS_Math::FPSlock = 0;
 			changeFPS = false;
-		else changeFPS = true;
-		FPSlock = (Shared -> FPSlocked);
-	}
-	
-	return vulkanResult;
-}
-
-uint32_t vulkanSwap (const void* VkQueue, const void* VkPresentInfoKHR) {
-	static uint8_t FPS_temp = 0;
-	static uint64_t starttick = 0;
-	static uint64_t endtick = 0;
-	static uint64_t deltatick = 0;
-	static uint64_t frameend = 0;
-	static uint64_t framedelta = 0;
-	static uint64_t frameavg = 0;
-	static uint8_t FPSlock = 0;
-	static uint32_t FPStiming = 0;
-	static uint8_t FPStickItr = 0;
-	static uint8_t range = 0;
-	static uint8_t rangeoverride = 0;
-	
-	bool FPSlock_delayed = false;
-	
-	if (!starttick) {
-		(Shared -> API) = 3;
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
-	}
-
-	uint32_t FPStimingoverride = 0;
-	if (LOCK::overwriteRefreshRate > 0) {
-		if (LOCK::overwriteRefreshRate >= 60.0) {
-			FPStimingoverride = (uint32_t)((double)systemtickfrequency / LOCK::overwriteRefreshRate) - 8000;
-			FPStimingoverride += 20 * rangeoverride;
 		}
-		else {
-			FPStimingoverride = (uint32_t)((double)systemtickfrequency / LOCK::overwriteRefreshRate) - 6000;		
-			FPStimingoverride += 20 * rangeoverride;
+		else if (LOCK::overwriteRefreshRate > 0 && (Shared -> FPSlocked)) {
+			changeFPS = true;
+			NX_FPS_Math::FPSlock = (Shared -> FPSlocked);
+			if (NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? (Shared -> displaySync) : 60))
+				NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+			else NX_FPS_Math::FPStiming = 0;
 		}
-	}
-	
+		
+		return vulkanResult;
+	}}
 
-	if ((FPStiming && !LOCK::blockDelayFPS && (!(Shared -> displaySync) || (Shared -> FPSlocked) < (Shared -> displaySync))) || FPStimingoverride) {
-		uint64_t tick = 0;
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
-		if ((tick - frameend) < (FPStimingoverride ? FPStimingoverride : FPStiming)) {
-			FPSlock_delayed = true;
-		}
-		while ((tick - frameend) < (FPStimingoverride ? FPStimingoverride : FPStiming)) {
-			svcSleepThread(-2);
-			svcSleepThread(10000);
-			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
-		}
-	}
+	uint32_t QueuePresent (const void* VkQueue, const void* VkPresentInfoKHR) {
 
-	uint32_t vulkanResult = ((vkQueuePresentKHR_0)(Address_weaks.vkQueuePresentKHR))(VkQueue, VkPresentInfoKHR);
-	((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&endtick);
-	framedelta = endtick - frameend;
-	frameavg = ((9*frameavg) + framedelta) / 10;
-	Stats.FPSavg = systemtickfrequency / (float)frameavg;
-
-	if ((FPSlock_delayed && FPStiming) || FPStimingoverride) {
-		if (Stats.FPSavg > ((float)FPSlock)) {
-			if (range < 200) {
-				FPStiming += 20;
-				range++;
-			}
+		if (!NX_FPS_Math::starttick) {
+			(Shared -> API) = 3;
+			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&NX_FPS_Math::starttick);
+			NX_FPS_Math::starttick2 = NX_FPS_Math::starttick;
 		}
-		else if ((std::lround(Stats.FPSavg) == FPSlock) && (Stats.FPSavg < (float)FPSlock)) {
-			if (range > 0) {
-				FPStiming -= 20;
-				range--;
-			}
-		}
+		
+		NX_FPS_Math::PreFrame();
 
-		if (Stats.FPSavg > LOCK::overwriteRefreshRate) {
-			if (rangeoverride < 200) {
-				rangeoverride++;
-			}
-		}
-		else if ((std::lround(Stats.FPSavg) == LOCK::overwriteRefreshRate) && (Stats.FPSavg <  LOCK::overwriteRefreshRate)) {
-			if (rangeoverride > 0) {
-				rangeoverride--;
-			}
-		}
-	}
+		uint32_t vulkanResult = ((vkQueuePresentKHR_0)(Address_weaks.vkQueuePresentKHR))(VkQueue, VkPresentInfoKHR);
+		NX_FPS_Math::PostFrame();
 
-	frameend = endtick;
-	
-	FPS_temp++;
-	deltatick = endtick - starttick;
-
-	Shared -> FPSticks[FPStickItr++] = framedelta;
-	FPStickItr %= 10;
-
-	if (deltatick > systemtickfrequency) {
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
-		Stats.FPS = FPS_temp - 1;
-		FPS_temp = 0;
-		(Shared -> FPS) = Stats.FPS;
-		if (changeFPS && !configRC && FPSlock) {
-			LOCK::applyPatch(configBuffer, configSize, FPSlock, (Shared -> displaySync));
-			(Shared -> patchApplied) = 1;
-		}
-		if (((_ZN2nn2oe16GetOperationModeEv)(Address_weaks.GetOperationMode))() == true && (Shared -> displaySync) != 0) {
-			(Shared -> displaySync) = 0;
-			FPSlock = 0;
-		}
-	}
-
-	(Shared -> FPSavg) = Stats.FPSavg;
-	(Shared -> pluginActive) = true;
-
-	if (FPSlock != (Shared -> FPSlocked) || (FPSlock && !FPStiming)) {
-		if (((Shared -> FPSlocked) < 60) && ((Shared -> FPSlocked) > 0)) {
-			FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 6000;
-		}
-		else FPStiming = 0;
-		if ((Shared -> FPSlocked) == 0) 
+		if ((Shared -> FPSlocked) == 0 && LOCK::overwriteRefreshRate == 0) {
+			NX_FPS_Math::FPStiming = 0;
+			NX_FPS_Math::FPSlock = 0;
 			changeFPS = false;
-		else changeFPS = true;
-		FPSlock = (Shared -> FPSlocked);
+		}
+		else if (LOCK::overwriteRefreshRate > 0 && (Shared -> FPSlocked)) {
+			changeFPS = true;
+			NX_FPS_Math::FPSlock = (Shared -> FPSlocked);
+			if (NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? (Shared -> displaySync) : 60))
+				NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+			else NX_FPS_Math::FPStiming = 0;
+		}
+		
+		return vulkanResult;
 	}
-	
-	return vulkanResult;
+
+	void* GetDeviceProcAddr(void* device, const char* vkFunction) {
+		if (!strcmp("vkQueuePresentKHR", vkFunction)) {
+			Address_weaks.vkQueuePresentKHR = (uintptr_t)((vkGetDeviceProcAddr_0)(Ptrs.vkGetDeviceProcAddr))(device, vkFunction);
+			return (void*)&vk::QueuePresent;
+		}
+		if (!strcmp("vkGetDeviceProcAddr", vkFunction)) {
+			Ptrs.vkGetDeviceProcAddr = (uintptr_t)((vkGetDeviceProcAddr_0)(Ptrs.vkGetDeviceProcAddr))(device, vkFunction);
+			return (void*)&vk::GetDeviceProcAddr;
+		}
+		return ((vkGetDeviceProcAddr_0)(Ptrs.vkGetDeviceProcAddr))(device, vkFunction);
+	}
+
+	void* GetInstanceProcAddr(void* instance, const char* vkFunction) {
+		if (!strcmp("vkQueuePresentKHR", vkFunction)) {
+			Address_weaks.vkQueuePresentKHR = (uintptr_t)((_vkGetInstanceProcAddr_0)(Address_weaks.vkGetInstanceProcAddr))(instance, vkFunction);
+			return (void*)&vk::QueuePresent;
+		}
+		if (!strcmp("vkGetDeviceProcAddr", vkFunction)) {
+			Ptrs.vkGetDeviceProcAddr = (uintptr_t)((_vkGetInstanceProcAddr_0)(Address_weaks.vkGetInstanceProcAddr))(instance, vkFunction);
+			return (void*)&vk::GetDeviceProcAddr;
+		}
+		return ((_vkGetInstanceProcAddr_0)(Address_weaks.vkGetInstanceProcAddr))(instance, vkFunction);
+	}
 }
 
-void* vkGetDeviceProcAddr(void* device, const char* vkFunction) {
-	if (!strcmp("vkQueuePresentKHR", vkFunction)) {
-		Address_weaks.vkQueuePresentKHR = (uintptr_t)((vkGetDeviceProcAddr_0)(Ptrs.vkGetDeviceProcAddr))(device, vkFunction);
-		return (void*)&vulkanSwap;
-	}
-	if (!strcmp("vkGetDeviceProcAddr", vkFunction)) {
-		Ptrs.vkGetDeviceProcAddr = (uintptr_t)((vkGetDeviceProcAddr_0)(Ptrs.vkGetDeviceProcAddr))(device, vkFunction);
-		return (void*)&vkGetDeviceProcAddr;
-	}
-	return ((vkGetDeviceProcAddr_0)(Ptrs.vkGetDeviceProcAddr))(device, vkFunction);
-}
-
-void* vkGetInstanceProcAddr(void* instance, const char* vkFunction) {
-	if (!strcmp("vkQueuePresentKHR", vkFunction)) {
-		Address_weaks.vkQueuePresentKHR = (uintptr_t)((_vkGetInstanceProcAddr_0)(Address_weaks.vkGetInstanceProcAddr))(instance, vkFunction);
-		return (void*)&vulkanSwap;
-	}
-	if (!strcmp("vkGetDeviceProcAddr", vkFunction)) {
-		Ptrs.vkGetDeviceProcAddr = (uintptr_t)((_vkGetInstanceProcAddr_0)(Address_weaks.vkGetInstanceProcAddr))(instance, vkFunction);
-		return (void*)&vkGetDeviceProcAddr;
-	}
-	return ((_vkGetInstanceProcAddr_0)(Address_weaks.vkGetInstanceProcAddr))(instance, vkFunction);
-}
-
-int eglInterval(const void* EGLDisplay, int interval) {
-	int result = false;
-	if (!changeFPS) {
-		result = ((eglSwapInterval_0)(Address_weaks.eglSwapInterval))(EGLDisplay, interval);
-		changedFPS = false;
-		(Shared -> FPSmode) = interval;
-	}
-	else if (interval < 0) {
-		interval *= -1;
-		if ((Shared -> FPSmode) != interval) {
+namespace EGL {
+	int Interval(const void* EGLDisplay, int interval) {
+		int result = false;
+		if (!changeFPS) {
 			result = ((eglSwapInterval_0)(Address_weaks.eglSwapInterval))(EGLDisplay, interval);
+			changedFPS = false;
 			(Shared -> FPSmode) = interval;
 		}
-		changedFPS = true;
-	}
-	return result;
-}
-
-int eglSwap (const void* EGLDisplay, const void* EGLSurface) {
-	static uint8_t FPS_temp = 0;
-	static uint64_t starttick = 0;
-	static uint64_t endtick = 0;
-	static uint64_t deltatick = 0;
-	static uint64_t frameend = 0;
-	static uint64_t framedelta = 0;
-	static uint64_t frameavg = 0;
-	static uint8_t FPSlock = 0;
-	static uint32_t FPStiming = 0;
-	static uint8_t FPStickItr = 0;
-	static uint8_t range = 0;
-	static uint8_t rangeoverride = 0;
-	
-	bool FPSlock_delayed = false;
-
-	if (!starttick) {
-		(Shared -> API) = 2;
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
+		else if (interval < 0) {
+			interval *= -1;
+			if ((Shared -> FPSmode) != interval) {
+				result = ((eglSwapInterval_0)(Address_weaks.eglSwapInterval))(EGLDisplay, interval);
+				(Shared -> FPSmode) = interval;
+			}
+			changedFPS = true;
+		}
+		return result;
 	}
 
-	uint32_t FPStimingoverride = 0;
-	(Shared -> forceOriginalRefreshRate) = false;
-	if (LOCK::overwriteRefreshRate > 0) {
-		if ((LOCK::overwriteRefreshRate == 30) || (LOCK::overwriteRefreshRate == 60)) {
-			(Shared -> forceOriginalRefreshRate) = true;
-			FPStimingoverride = 1;
-			eglInterval(EGLDisplay, (-60 / LOCK::overwriteRefreshRate));
-			
-		}
-		else {
-			eglInterval(EGLDisplay, -1);
-			if (LOCK::overwriteRefreshRate >= 60.0) {
-				FPStimingoverride = (uint32_t)((double)systemtickfrequency / LOCK::overwriteRefreshRate) - 8000;
-				FPStimingoverride += 20 * rangeoverride;
-			}
-			else {
-				FPStimingoverride = (uint32_t)((double)systemtickfrequency / LOCK::overwriteRefreshRate) - 6000;		
-				FPStimingoverride += 20 * rangeoverride;
-			}
-		}
-	}
+	int Swap (const void* EGLDisplay, const void* EGLSurface) {
 
-	if ((FPStiming && !LOCK::blockDelayFPS && (!(Shared -> displaySync) || (Shared -> FPSlocked) < (Shared -> displaySync))) || FPStimingoverride) {
-		uint64_t tick = 0;
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
-		if ((tick - frameend) < (FPStimingoverride ? FPStimingoverride : FPStiming)) {
-			FPSlock_delayed = true;
+		if (!NX_FPS_Math::starttick) {
+			(Shared -> API) = 2;
+			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&NX_FPS_Math::starttick);
+			NX_FPS_Math::starttick2 = NX_FPS_Math::starttick;
 		}
-		while ((tick - frameend) < (FPStimingoverride ? FPStimingoverride : FPStiming)) {
-			svcSleepThread(-2);
-			svcSleepThread(10000);
-			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
-		}
-	}
-	
-	int result = ((eglSwapBuffers_0)(Address_weaks.eglSwapBuffers))(EGLDisplay, EGLSurface);
-	((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&endtick);
-	framedelta = endtick - frameend;
-	frameavg = ((9*frameavg) + framedelta) / 10;
-	Stats.FPSavg = systemtickfrequency / (float)frameavg;
+		
+		NX_FPS_Math::PreFrame();
+		
+		int result = ((eglSwapBuffers_0)(Address_weaks.eglSwapBuffers))(EGLDisplay, EGLSurface);
+		NX_FPS_Math::PostFrame();
 
-	if ((FPSlock_delayed && FPStiming) || FPStimingoverride) {
-		if (Stats.FPSavg > ((float)FPSlock)) {
-			if (range < 200) {
-				FPStiming += 20;
-				range++;
-			}
-		}
-		else if ((std::lround(Stats.FPSavg) == FPSlock) && (Stats.FPSavg < (float)FPSlock)) {
-			if (range > 0) {
-				FPStiming -= 20;
-				range--;
-			}
-		}
-		if (Stats.FPSavg > LOCK::overwriteRefreshRate) {
-			if (rangeoverride < 200) {
-				rangeoverride++;
-			}
-		}
-		else if ((std::lround(Stats.FPSavg) == LOCK::overwriteRefreshRate) && (Stats.FPSavg <  LOCK::overwriteRefreshRate)) {
-			if (rangeoverride > 0) {
-				rangeoverride--;
-			}
-		}
-	}
-
-	frameend = endtick;
-	
-	FPS_temp++;
-	deltatick = endtick - starttick;
-
-	Shared -> FPSticks[FPStickItr++] = framedelta;
-	FPStickItr %= 10;
-
-	if (deltatick > systemtickfrequency) {
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
-		Stats.FPS = FPS_temp - 1;
-		FPS_temp = 0;
-		(Shared -> FPS) = Stats.FPS;
-		if (changeFPS && !configRC && FPSlock) {
-			LOCK::applyPatch(configBuffer, configSize, FPSlock, (Shared -> displaySync));
-			(Shared -> patchApplied) = 1;
-		}
-		if (((_ZN2nn2oe16GetOperationModeEv)(Address_weaks.GetOperationMode))() == true && (Shared -> displaySync) != 0) {
-			(Shared -> displaySync) = 0;
-			FPSlock = 0;
-		}
-	}
-	
-	(Shared -> FPSavg) = Stats.FPSavg;
-	(Shared -> pluginActive) = true;
-
-	if ((FPSlock != (Shared -> FPSlocked)) || (FPSlock && !FPStiming) || ((Shared -> FPSlocked) > 30 && (Shared -> FPSmode) > 1)) {
-		changeFPS = true;
-		changedFPS = false;
-		if ((Shared -> FPSlocked) == 0) {
-			FPStiming = 0;
+		if ((Shared -> FPSlocked) == 0 && LOCK::overwriteRefreshRate == 0) {
+			NX_FPS_Math::FPStiming = 0;
+			NX_FPS_Math::FPSlock = 0;
 			changeFPS = false;
-			FPSlock = (Shared -> FPSlocked);
 		}
-		else if ((Shared -> FPSlocked) <= 30) {
-			eglInterval(EGLDisplay, -2);
-			if ((Shared -> FPSlocked) != 30) {
-				FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 6000;
+		else if (Shared -> FPSlocked || LOCK::overwriteRefreshRate > 0) {
+			changeFPS = true;
+			NX_FPS_Math::FPSlock = (Shared -> FPSlocked);
+			if (NX_FPS_Math::new_fpslock <= ((Shared -> displaySync) ? ((Shared -> displaySync) / 4) : 15)) {
+				if ((Shared -> FPSmode) != 4)
+					Interval(EGLDisplay, -4);
+				if ((NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? ((Shared -> displaySync) / 4) : 15))
+				|| (Shared -> ZeroSync)) {
+					if (NX_FPS_Math::new_fpslock == ((Shared -> displaySync) ? ((Shared -> displaySync) / 4) : 15)) {
+						NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 8000;
+					}
+					else NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+				}
+				else NX_FPS_Math::FPStiming = 0;			
 			}
-			else FPStiming = 0;
-		}
-		else {
-			eglInterval(EGLDisplay, -1);
-			if ((Shared -> FPSlocked) != 60) {
-				FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 6000;
+			else if (NX_FPS_Math::new_fpslock <= ((Shared -> displaySync) ? ((Shared -> displaySync) / 3) : 20)) {
+				if ((Shared -> FPSmode) != 3)
+					Interval(EGLDisplay, -3);
+				if ((NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? ((Shared -> displaySync) / 3) : 20))
+				|| (Shared -> ZeroSync)) {
+					if (NX_FPS_Math::new_fpslock == ((Shared -> displaySync) ? ((Shared -> displaySync) / 3) : 20)) {
+						NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 8000;
+					}
+					else NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+				}
+				else NX_FPS_Math::FPStiming = 0;			
 			}
-			else FPStiming = 0;
+			else if (NX_FPS_Math::new_fpslock <= ((Shared -> displaySync) ? ((Shared -> displaySync) / 2) : 30)) {
+				if ((Shared -> FPSmode) != 2)
+					Interval(EGLDisplay, -2);
+				if (NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? ((Shared -> displaySync) / 2) : 30)
+				|| (Shared -> ZeroSync)) {
+					if (NX_FPS_Math::new_fpslock == ((Shared -> displaySync) ? ((Shared -> displaySync) / 2) : 30)) {
+						NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 8000;
+					}
+					else NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+				}
+				else NX_FPS_Math::FPStiming = 0;			
+			}
+			else if (NX_FPS_Math::new_fpslock > ((Shared -> displaySync) ? ((Shared -> displaySync) / 2) : 30)) {
+				if ((Shared -> FPSmode) != 1)
+					Interval(EGLDisplay, -1);
+				if ((NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? (Shared -> displaySync) : 60))
+				|| (Shared -> ZeroSync)) {
+					if (NX_FPS_Math::new_fpslock == ((Shared -> displaySync) ? (Shared -> displaySync) : 60)) {
+						NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 8000;
+					}
+					else NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+				}
+				else NX_FPS_Math::FPStiming = 0;
+			}
 		}
-		if (changedFPS) {
-			FPSlock = (Shared -> FPSlocked);
+
+		return result;
+	}
+
+	uintptr_t GetProc(const char* eglName) {
+		if (!strcmp(eglName, "eglSwapInterval")) {
+			return (uintptr_t)&Interval;
 		}
-	}
-
-	return result;
-}
-
-uintptr_t eglGetProc(const char* eglName) {
-	if (!strcmp(eglName, "eglSwapInterval")) {
-		return Address.eglSwapInterval;
-	}
-	else if (!strcmp(eglName, "eglSwapBuffers")) {
-		return Address.eglSwapBuffers;
-	}
-	return ((eglGetProcAddress_0)(Address_weaks.eglGetProcAddress))(eglName);
-}
-
-bool nvnWindowInitialize(const NVNWindow* nvnWindow, struct nvnWindowBuilder* windowBuilder) {
-	m_nvnWindow = (NVNWindow*)nvnWindow;
-	if (!(Shared -> Buffers)) {
-		(Shared -> Buffers) = windowBuilder -> numBufferedFrames;
-		if ((Shared -> SetBuffers) >= 2 && (Shared -> SetBuffers) <= windowBuilder -> numBufferedFrames) {
-			windowBuilder -> numBufferedFrames = (Shared -> SetBuffers);
+		else if (!strcmp(eglName, "eglSwapBuffers")) {
+			return (uintptr_t)&Swap;
 		}
-		(Shared -> ActiveBuffers) = windowBuilder -> numBufferedFrames;	
+		return ((eglGetProcAddress_0)(Address_weaks.eglGetProcAddress))(eglName);
 	}
-	return ((nvnWindowInitialize_0)(Ptrs.nvnWindowInitialize))(nvnWindow, windowBuilder);
 }
 
-void nvnWindowBuilderSetTextures(const nvnWindowBuilder* nvnWindowBuilder, int numBufferedFrames, NVNTexture** nvnTextures) {
-	(Shared -> Buffers) = numBufferedFrames;
-	for (int i = 0; i < numBufferedFrames; i++) {
-		framebufferTextures[i] = nvnTextures[i];
+namespace NVN {
+	bool WindowInitialize(const NVNWindow* nvnWindow, struct nvnWindowBuilder* windowBuilder) {
+		m_nvnWindow = (NVNWindow*)nvnWindow;
+		if (!(Shared -> Buffers)) {
+			(Shared -> Buffers) = windowBuilder -> numBufferedFrames;
+			if ((Shared -> SetBuffers) >= 2 && (Shared -> SetBuffers) <= windowBuilder -> numBufferedFrames) {
+				windowBuilder -> numBufferedFrames = (Shared -> SetBuffers);
+			}
+			(Shared -> ActiveBuffers) = windowBuilder -> numBufferedFrames;	
+		}
+		return ((nvnWindowInitialize_0)(Ptrs.nvnWindowInitialize))(nvnWindow, windowBuilder);
 	}
-	if ((Shared -> SetBuffers) >= 2 && (Shared -> SetBuffers) <= numBufferedFrames) {
-		numBufferedFrames = (Shared -> SetBuffers);
-	}
-	(Shared -> ActiveBuffers) = numBufferedFrames;
-	return ((nvnBuilderSetTextures_0)(Ptrs.nvnWindowBuilderSetTextures))(nvnWindowBuilder, numBufferedFrames, nvnTextures);
-}
 
-void nvnWindowSetNumActiveTextures(const NVNWindow* nvnWindow, int numBufferedFrames) {
-	(Shared -> SetActiveBuffers) = numBufferedFrames;
-	if ((Shared -> SetBuffers) >= 2 && (Shared -> SetBuffers) <= (Shared -> Buffers)) {
-		numBufferedFrames = (Shared -> SetBuffers);
+	//This function accepts pointer and how much frames is passed to framebuffer
+	void WindowBuilderSetTextures(const nvnWindowBuilder* nvnWindowBuilder, int numBufferedFrames, NVNTexture** nvnTextures) {
+		(Shared -> Buffers) = numBufferedFrames;
+		for (int i = 0; i < numBufferedFrames; i++) {
+			framebufferTextures[i] = nvnTextures[i];
+		}
+		if ((Shared -> SetBuffers) >= 2 && (Shared -> SetBuffers) <= numBufferedFrames) {
+			numBufferedFrames = (Shared -> SetBuffers);
+		}
+		(Shared -> ActiveBuffers) = numBufferedFrames;
+		return ((nvnBuilderSetTextures_0)(Ptrs.nvnWindowBuilderSetTextures))(nvnWindowBuilder, numBufferedFrames, nvnTextures);
 	}
-	(Shared -> ActiveBuffers) = numBufferedFrames;
-	return ((nvnWindowSetNumActiveTextures_0)(Ptrs.nvnWindowSetNumActiveTextures))(nvnWindow, numBufferedFrames);
-}
 
-void nvnSetPresentInterval(const NVNWindow* nvnWindow, int mode) {
-	if (mode < 0) {
-		mode *= -1;
-		if ((Shared -> FPSmode) != mode) {
+	//This function can change on the fly how much frames from framebuffer game can use, it cannot be more than amount passed to nvnWindowBuilderSetTextures
+	void WindowSetNumActiveTextures(const NVNWindow* nvnWindow, int numBufferedFrames) {
+		(Shared -> SetActiveBuffers) = numBufferedFrames;
+		if ((Shared -> SetBuffers) >= 2 && (Shared -> SetBuffers) <= (Shared -> Buffers)) {
+			numBufferedFrames = (Shared -> SetBuffers);
+		}
+		(Shared -> ActiveBuffers) = numBufferedFrames;
+		return ((nvnWindowSetNumActiveTextures_0)(Ptrs.nvnWindowSetNumActiveTextures))(nvnWindow, numBufferedFrames);
+	}
+
+	//This function changes amount of vsync events it must wait before frame is passed to display.
+	//In case of 60 Hz, if mode is 2 game is blocked to 30 FPS
+	void SetPresentInterval(const NVNWindow* nvnWindow, int mode) {
+		if (mode < 0) {
+			mode *= -1;
+			if ((Shared -> FPSmode) != mode) {
+				((nvnSetPresentInterval_0)(Ptrs.nvnWindowSetPresentInterval))(nvnWindow, mode);
+				(Shared -> FPSmode) = mode;
+			}
+			changedFPS = true;
+		}
+		else if (!changeFPS) {
 			((nvnSetPresentInterval_0)(Ptrs.nvnWindowSetPresentInterval))(nvnWindow, mode);
+			changedFPS = false;
 			(Shared -> FPSmode) = mode;
 		}
-		changedFPS = true;
-	}
-	else if (!changeFPS) {
-		((nvnSetPresentInterval_0)(Ptrs.nvnWindowSetPresentInterval))(nvnWindow, mode);
-		changedFPS = false;
-		(Shared -> FPSmode) = mode;
-	}
-	return;
-}
-
-void* nvnSyncWait0(const void* _this, uint64_t timeout_ns) {
-	uint64_t endFrameTick = 0;
-	((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&endFrameTick);
-	if (_this == WindowSync && (Shared -> ActiveBuffers) == 2) {
-		if ((Shared -> ZeroSync) == ZeroSyncType_Semi) {
-			u64 FrameTarget = (systemtickfrequency/60) - 8000;
-			s64 new_timeout = (FrameTarget - (endFrameTick - startFrameTick)) - 19200;
-			if ((Shared -> FPSlocked) == 60) {
-				new_timeout = (systemtickfrequency/101) - (endFrameTick - startFrameTick);
-			}
-			if (new_timeout > 0) {
-				timeout_ns = ((_ZN2nn2os17ConvertToTimeSpanENS0_4TickE_0)(Address_weaks.ConvertToTimeSpan))(new_timeout);
-			}
-			else timeout_ns = 0;
-		}
-		else if ((Shared -> ZeroSync) == ZeroSyncType_Soft) 
-			timeout_ns = 0;
-	}
-	return ((nvnSyncWait_0)(Ptrs.nvnSyncWait))(_this, timeout_ns);
-}
-
-bool nvnPresentedTexture = false;
-
-void nvnPresentTexture(const void* _this, const NVNWindow* nvnWindow, const void* unk3) {
-	static uint8_t FPS_temp = 0;
-	static uint64_t starttick = 0;
-	static uint64_t endtick = 0;
-	static uint64_t deltatick = 0;
-	static uint64_t frameend = 0;
-	static uint64_t framedelta = 0;
-	static uint64_t frameavg = 0;
-	static uint8_t FPSlock = 0;
-	static uint32_t FPStiming = 0;
-	static uint8_t FPStickItr = 0;
-	static uint8_t range = 0;
-	static uint8_t rangeoverride = 0;
-	
-	bool FPSlock_delayed = false;
-
-	if (!starttick) {
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
-		(Shared -> FPSmode) = (uint8_t)((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow);
+		return;
 	}
 
-	if (FPSlock) {
-		if (((Shared -> ZeroSync) == ZeroSyncType_None) && FPStiming && ((Shared -> displaySync) == FPSlock || ((Shared -> displaySync) == 0 && (FPSlock == 60 || FPSlock == 30)))) {
-			FPStiming = 0;
-		}
-		else if (((Shared -> ZeroSync) != ZeroSyncType_None) && !FPStiming) {
-			if (FPSlock == 60) {
-				FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 8000;
-			}
-			else FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 6000;
-		}
-	}
-
-	uint32_t FPStimingoverride = 0;
-	(Shared -> forceOriginalRefreshRate) = false;
-	if (LOCK::overwriteRefreshRate > 0) {
-		if ((LOCK::overwriteRefreshRate == 30) || (LOCK::overwriteRefreshRate == 60)) {
-			(Shared -> forceOriginalRefreshRate) = true;
-			FPStimingoverride = 1;
-			nvnSetPresentInterval(nvnWindow, (-60 / LOCK::overwriteRefreshRate));
-		}
-		else {
-			nvnSetPresentInterval(nvnWindow, -1);
-			if (LOCK::overwriteRefreshRate >= 60.0) {
-				FPStimingoverride = (uint32_t)((double)systemtickfrequency / LOCK::overwriteRefreshRate) - 8000;
-				FPStimingoverride += 20 * rangeoverride;
-			}
-			else {
-				FPStimingoverride = (uint32_t)((double)systemtickfrequency / LOCK::overwriteRefreshRate) - 6000;		
-				FPStimingoverride += 20 * rangeoverride;
-			}
-		}
-	}
-
-	if ((FPStiming && !LOCK::blockDelayFPS && (!(Shared -> displaySync) || (Shared -> FPSlocked) < (Shared -> displaySync))) || FPStimingoverride) {
-		uint64_t tick = 0;
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
-		if ((tick - frameend) < (FPStimingoverride ? FPStimingoverride : FPStiming)) {
-			FPSlock_delayed = true;
-		}
-		while ((tick - frameend) < (FPStimingoverride ? FPStimingoverride : FPStiming)) {
-			svcSleepThread(-2);
-			svcSleepThread(10000);
-			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&tick);
-		}
-	}
-	
-	((nvnQueuePresentTexture_0)(Ptrs.nvnQueuePresentTexture))(_this, nvnWindow, unk3);
-	
-	nvnPresentedTexture = true;
-	((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&endtick);
-	framedelta = endtick - frameend;
-
-	Shared -> FPSticks[FPStickItr++] = framedelta;
-	FPStickItr %= 10;
-	
-	frameavg = ((9*frameavg) + framedelta) / 10;
-	Stats.FPSavg = systemtickfrequency / (float)frameavg;
-
-	if ((FPSlock_delayed && FPStiming) || FPStimingoverride) {
-		if (Stats.FPSavg > ((float)FPSlock)) {
-			if (range < 200) {
-				FPStiming += 20;
-				range++;
-			}
-		}
-		else if ((std::lround(Stats.FPSavg) == FPSlock) && (Stats.FPSavg < (float)FPSlock)) {
-			if (range > 0) {
-				FPStiming -= 20;
-				range--;
-			}
-		}
-
-		if (Stats.FPSavg > LOCK::overwriteRefreshRate) {
-			if (rangeoverride < 200) {
-				rangeoverride++;
-			}
-		}
-		else if ((std::lround(Stats.FPSavg) == LOCK::overwriteRefreshRate) && (Stats.FPSavg <  LOCK::overwriteRefreshRate)) {
-			if (rangeoverride > 0) {
-				rangeoverride--;
-			}
-		}
-	}
-	frameend = endtick;
-	FPS_temp++;
-	deltatick = endtick - starttick;
-	if (deltatick > systemtickfrequency) {
-		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&starttick);
-		Stats.FPS = FPS_temp - 1;
-		FPS_temp = 0;
-		(Shared -> FPS) = Stats.FPS;
-		(Shared -> FPSmode) = (uint8_t)((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow);
-		if (changeFPS && !configRC && FPSlock) {
-			LOCK::applyPatch(configBuffer, configSize, FPSlock, (Shared -> displaySync));
-			(Shared -> patchApplied) = 1;
-		}
-		if (((_ZN2nn2oe16GetOperationModeEv)(Address_weaks.GetOperationMode))() == true && (Shared -> displaySync) != 0) {
-			(Shared -> displaySync) = 0;
-			FPSlock = 0;
-		}
-	}
-	(Shared -> FPSavg) = Stats.FPSavg;
-	
-	
-	(Shared -> pluginActive) = true;
-	
-	if ((FPSlock != (Shared -> FPSlocked)) || (FPSlock && !FPStiming) || ((Shared -> FPSlocked) > 30 && (Shared -> FPSmode) > 1)) {
-		changeFPS = true;
-		changedFPS = false;
-		if ((Shared -> FPSlocked) == 0) {
-			FPStiming = 0;
-			changeFPS = false;
-			FPSlock = (Shared -> FPSlocked);
-		}
-		else if ((Shared -> displaySync) == 0 && ((Shared -> FPSlocked) <= 30)) {
-			nvnSetPresentInterval(nvnWindow, -2);
-			if ((Shared -> FPSlocked) != 30 || (Shared -> ZeroSync)) {
-				if ((Shared -> FPSlocked) == 30) {
-					FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 8000;
-				}
-				else FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 6000;
-			}
-			else FPStiming = 0;
-		}
-		else {
-			nvnSetPresentInterval(nvnWindow, -2); //This allows in game with glitched interval to unlock 60 FPS, f.e. WRC Generations
-			nvnSetPresentInterval(nvnWindow, -1);
-			if ((Shared -> FPSlocked) != 60 || (Shared -> ZeroSync)) {
+	//This function is used to wait until all events passed to nvnSync are signaled.
+	//Some games are using it to make sure that double buffer vsync is maintained.
+	void* SyncWait0(const void* _this, uint64_t timeout_ns) {
+		uint64_t endFrameTick = 0;
+		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&endFrameTick);
+		if (_this == WindowSync && (Shared -> ActiveBuffers) == 2) {
+			if ((Shared -> ZeroSync) == ZeroSyncType_Semi) {
+				u64 FrameTarget = (systemtickfrequency/60) - 8000;
+				s64 new_timeout = (FrameTarget - (endFrameTick - startFrameTick)) - 19200;
 				if ((Shared -> FPSlocked) == 60) {
-					FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 8000;
+					new_timeout = (systemtickfrequency/101) - (endFrameTick - startFrameTick);
 				}
-				else FPStiming = (systemtickfrequency/((Shared -> FPSlocked))) - 6000;
+				if (new_timeout > 0) {
+					timeout_ns = ((_ZN2nn2os17ConvertToTimeSpanENS0_4TickE_0)(Address_weaks.ConvertToTimeSpan))(new_timeout);
+				}
+				else timeout_ns = 0;
 			}
-			else FPStiming = 0;
+			else if ((Shared -> ZeroSync) == ZeroSyncType_Soft) 
+				timeout_ns = 0;
 		}
-		if (changedFPS) {
-			FPSlock = (Shared -> FPSlocked);
-		}
+		return ((nvnSyncWait_0)(Ptrs.nvnSyncWait))(_this, timeout_ns);
 	}
 
-	
-	
-	return;
-}
+	bool nvnPresentedTexture = false;
 
-void* nvnAcquireTexture(const NVNWindow* nvnWindow, const void* nvnSync, const void* index) {
-	if (WindowSync != nvnSync) {
-		WindowSync = (void*)nvnSync;
+	//This function accepts which frame pushed to nvnWindowBuilderSetTexture should be shown on screen.
+	//It pushes that frame into queue
+	void PresentTexture(const void* _this, const NVNWindow* nvnWindow, const void* unk3) {
+
+		if (!NX_FPS_Math::starttick) {
+			((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&NX_FPS_Math::starttick);
+			NX_FPS_Math::starttick2 = NX_FPS_Math::starttick;
+			(Shared -> FPSmode) = (uint8_t)((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow);
+		}
+		
+		NX_FPS_Math::PreFrame();
+		
+		((nvnQueuePresentTexture_0)(Ptrs.nvnQueuePresentTexture))(_this, nvnWindow, unk3);
+		
+		nvnPresentedTexture = true;
+		NX_FPS_Math::PostFrame();
+		(Shared -> FPSmode) = (uint8_t)((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow);
+
+		if ((Shared -> FPSlocked) == 0 && LOCK::overwriteRefreshRate == 0) {
+			NX_FPS_Math::FPStiming = 0;
+			NX_FPS_Math::FPSlock = 0;
+			changeFPS = false;
+		}
+		else if (Shared -> FPSlocked || LOCK::overwriteRefreshRate > 0) {
+			changeFPS = true;
+			NX_FPS_Math::FPSlock = (Shared -> FPSlocked);
+			if (NX_FPS_Math::new_fpslock <= ((Shared -> displaySync) ? ((Shared -> displaySync) / 4) : 15)) {
+				if (((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow) != 4)
+					NVN::SetPresentInterval(nvnWindow, -4);
+				if ((NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? ((Shared -> displaySync) / 4) : 15))
+				|| (Shared -> ZeroSync)) {
+					NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+					if (NX_FPS_Math::new_fpslock == ((Shared -> displaySync) ? ((Shared -> displaySync) / 4) : 15)) {
+						NX_FPS_Math::FPStiming -= 2000;
+					}
+				}
+				else NX_FPS_Math::FPStiming = 0;			
+			}
+			else if (NX_FPS_Math::new_fpslock <= ((Shared -> displaySync) ? ((Shared -> displaySync) / 3) : 20)) {
+				if (((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow) != 3)
+					NVN::SetPresentInterval(nvnWindow, -3);
+				if ((NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? ((Shared -> displaySync) / 3) : 20))
+				|| (Shared -> ZeroSync)) {
+					NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+					if (NX_FPS_Math::new_fpslock == ((Shared -> displaySync) ? ((Shared -> displaySync) / 3) : 20)) {
+						NX_FPS_Math::FPStiming -= 2000;
+					}
+				}
+				else NX_FPS_Math::FPStiming = 0;			
+			}
+			else if (NX_FPS_Math::new_fpslock <= ((Shared -> displaySync) ? ((Shared -> displaySync) / 2) : 30)) {
+				if (((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow) != 2)
+					NVN::SetPresentInterval(nvnWindow, -2);
+				if (NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? ((Shared -> displaySync) / 2) : 30)
+				|| (Shared -> ZeroSync)) {
+					NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+					if (NX_FPS_Math::new_fpslock == ((Shared -> displaySync) ? ((Shared -> displaySync) / 2) : 30)) {
+						NX_FPS_Math::FPStiming -= 2000;
+					}
+				}
+				else NX_FPS_Math::FPStiming = 0;			
+			}
+			else if (NX_FPS_Math::new_fpslock > ((Shared -> displaySync) ? ((Shared -> displaySync) / 2) : 30)) {
+				if (((nvnGetPresentInterval_0)(Ptrs.nvnWindowGetPresentInterval))(nvnWindow) != 1) {
+					NVN::SetPresentInterval(nvnWindow, -2); //This allows in game with glitched interval to unlock 60 FPS, f.e. WRC Generations
+					NVN::SetPresentInterval(nvnWindow, -1);
+				}
+				if ((NX_FPS_Math::new_fpslock != ((Shared -> displaySync) ? (Shared -> displaySync) : 60))
+				|| (Shared -> ZeroSync)) {
+					NX_FPS_Math::FPStiming = (systemtickfrequency/NX_FPS_Math::new_fpslock) - 6000;
+					if (NX_FPS_Math::new_fpslock == ((Shared -> displaySync) ? (Shared -> displaySync) : 60)) {
+						NX_FPS_Math::FPStiming -= 2000;
+					}
+				}
+				else NX_FPS_Math::FPStiming = 0;
+			}
+		}
+		
+		return;
 	}
-	void* ret = ((nvnWindowAcquireTexture_0)(Ptrs.nvnWindowAcquireTexture))(nvnWindow, nvnSync, index);
-	((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&startFrameTick);
-	return ret;
-}
 
-struct nvnCommandBuffer {
-	char reserved[0x80];
-};
+	//This function retrieves number of frame which is currently free to use.
+	//Blocks execution if no frame is available at the moment
+	void* AcquireTexture(const NVNWindow* nvnWindow, const void* nvnSync, const void* index) {
+		if (WindowSync != nvnSync) {
+			WindowSync = (void*)nvnSync;
+		}
+		void* ret = ((nvnWindowAcquireTexture_0)(Ptrs.nvnWindowAcquireTexture))(nvnWindow, nvnSync, index);
+		((_ZN2nn2os13GetSystemTickEv_0)(Address_weaks.GetSystemTick))(&startFrameTick);
+		return ret;
+	}
 
-resolutionCalls m_resolutionRenderCalls[8] = {0};
-resolutionCalls m_resolutionViewportCalls[8] = {0};
+	struct nvnCommandBuffer {
+		char reserved[0x80];
+	};
 
-void* nvnCommandBufferSetViewports(nvnCommandBuffer* cmdBuf, int start, int count, NVNViewport* viewports) {
-	if (resolutionLookup) for (int i = start; i < count; i++) {
-		if (viewports[i].height > 1.f && viewports[i].width > 1.f && viewports[i].x == 0.f && viewports[i].y == 0.f) {
-			uint16_t width = (uint16_t)(viewports[i].width);
-			uint16_t height = (uint16_t)(viewports[i].height);
+	resolutionCalls m_resolutionRenderCalls[8] = {0};
+	resolutionCalls m_resolutionViewportCalls[8] = {0};
+
+	//Sets resolutions and start point of passed to command buffer textures, they cannot be bigger than texture are originally
+	void* CommandBufferSetViewports(nvnCommandBuffer* cmdBuf, int start, int count, NVNViewport* viewports) {
+		if (resolutionLookup) for (int i = start; i < count; i++) {
+			if (viewports[i].height > 1.f && viewports[i].width > 1.f && viewports[i].x == 0.f && viewports[i].y == 0.f) {
+				uint16_t width = (uint16_t)(viewports[i].width);
+				uint16_t height = (uint16_t)(viewports[i].height);
+				int ratio = (width * 10) / height;
+				if (ratio >= 12 && ratio <= 18) {
+					//Dynamic Resolution is always the second value passed
+					for (size_t i = 0; i < 8; i++) {
+						if (width == m_resolutionViewportCalls[i].width) {
+							m_resolutionViewportCalls[i].calls++;
+							break;
+						}
+						if (m_resolutionViewportCalls[i].width == 0) {
+							m_resolutionViewportCalls[i].width = width;
+							m_resolutionViewportCalls[i].height = height;
+							m_resolutionViewportCalls[i].calls = 1;
+							break;
+						}
+					}			
+				}
+			}
+		}
+		return ((nvnCommandBufferSetViewports_0)(Ptrs.nvnCommandBufferSetViewports))(cmdBuf, start, count, viewports);
+	}
+
+	//Sets resolutions and start point of passed to command buffer textures, they cannot be bigger than texture are originally
+	void* CommandBufferSetViewport(nvnCommandBuffer* cmdBuf, int x, int y, int width, int height) {
+		if (resolutionLookup && height > 1 && width > 1 && !x && !y) {
 			int ratio = (width * 10) / height;
 			if (ratio >= 12 && ratio <= 18) {
 				//Dynamic Resolution is always the second value passed
@@ -944,142 +719,121 @@ void* nvnCommandBufferSetViewports(nvnCommandBuffer* cmdBuf, int start, int coun
 				}			
 			}
 		}
+		return ((nvnCommandBufferSetViewport_0)(Ptrs.nvnCommandBufferSetViewport))(cmdBuf, x, y, width, height);
 	}
-	return ((nvnCommandBufferSetViewports_0)(Ptrs.nvnCommandBufferSetViewports))(cmdBuf, start, count, viewports);
-}
 
-void* nvnCommandBufferSetViewport(nvnCommandBuffer* cmdBuf, int x, int y, int width, int height) {
-	if (resolutionLookup && height > 1 && width > 1 && !x && !y) {
-		int ratio = (width * 10) / height;
-		if (ratio >= 12 && ratio <= 18) {
-			//Dynamic Resolution is always the second value passed
-			for (size_t i = 0; i < 8; i++) {
-				if (width == m_resolutionViewportCalls[i].width) {
-					m_resolutionViewportCalls[i].calls++;
-					break;
-				}
-				if (m_resolutionViewportCalls[i].width == 0) {
-					m_resolutionViewportCalls[i].width = width;
-					m_resolutionViewportCalls[i].height = height;
-					m_resolutionViewportCalls[i].calls = 1;
-					break;
-				}
-			}			
+	void* CommandBufferSetRenderTargets(nvnCommandBuffer* cmdBuf, int numTextures, NVNTexture** texture, NVNTextureView** textureView, NVNTexture* depthTexture, NVNTextureView* depthView) {
+		if (!resolutionLookup && Shared -> renderCalls[0].calls == 0xFFFF) {
+			resolutionLookup = true;
+			Shared -> renderCalls[0].calls = 0;
 		}
-	}
-	return ((nvnCommandBufferSetViewport_0)(Ptrs.nvnCommandBufferSetViewport))(cmdBuf, x, y, width, height);
-}
-
-void* nvnCommandBufferSetRenderTargets(nvnCommandBuffer* cmdBuf, int numTextures, NVNTexture** texture, NVNTextureView** textureView, NVNTexture* depthTexture, NVNTextureView* depthView) {
-	if (!resolutionLookup && Shared -> renderCalls[0].calls == 0xFFFF) {
-		resolutionLookup = true;
-		Shared -> renderCalls[0].calls = 0;
-	}
-	if (resolutionLookup && depthTexture != NULL && texture != NULL) {
-		uint16_t depth_width = ((nvnTextureGetWidth_0)(Ptrs.nvnTextureGetWidth))(depthTexture);
-		uint16_t depth_height = ((nvnTextureGetHeight_0)(Ptrs.nvnTextureGetHeight))(depthTexture);
-		int depth_format = ((nvnTextureGetFormat_0)(Ptrs.nvnTextureGetFormat))(depthTexture);
-		if (depth_width > 1 && depth_height > 1 && (depth_format >= 51 && depth_format <= 54)) {
-			if (nvnPresentedTexture) {
-				memcpy(Shared -> renderCalls, m_resolutionRenderCalls, sizeof(m_resolutionRenderCalls));
-				memcpy(Shared -> viewportCalls, m_resolutionViewportCalls, sizeof(m_resolutionViewportCalls));
-				memset(&m_resolutionRenderCalls, 0, sizeof(m_resolutionRenderCalls));
-				memset(&m_resolutionViewportCalls, 0, sizeof(m_resolutionViewportCalls));
-				nvnPresentedTexture = false;
-			}
-			bool found = false;
-			int ratio = ((depth_width * 10) / (depth_height));
-			if (ratio < 12 || ratio > 18) {
-				found = true;
-			}
-			if (!found) {
-				for (size_t i = 0; i < 8; i++) {
-					if (depth_width == m_resolutionRenderCalls[i].width) {
-						m_resolutionRenderCalls[i].calls++;
-						break;
-					}
-					if (m_resolutionRenderCalls[i].width == 0) {
-						m_resolutionRenderCalls[i].width = depth_width;
-						m_resolutionRenderCalls[i].height = depth_height;
-						m_resolutionRenderCalls[i].calls = 1;
-						break;
+		if (resolutionLookup && depthTexture != NULL && texture != NULL) {
+			uint16_t depth_width = ((nvnTextureGetWidth_0)(Ptrs.nvnTextureGetWidth))(depthTexture);
+			uint16_t depth_height = ((nvnTextureGetHeight_0)(Ptrs.nvnTextureGetHeight))(depthTexture);
+			int depth_format = ((nvnTextureGetFormat_0)(Ptrs.nvnTextureGetFormat))(depthTexture);
+			if (depth_width > 1 && depth_height > 1 && (depth_format >= 51 && depth_format <= 54)) {
+				if (nvnPresentedTexture) {
+					memcpy(Shared -> renderCalls, m_resolutionRenderCalls, sizeof(m_resolutionRenderCalls));
+					memcpy(Shared -> viewportCalls, m_resolutionViewportCalls, sizeof(m_resolutionViewportCalls));
+					memset(&m_resolutionRenderCalls, 0, sizeof(m_resolutionRenderCalls));
+					memset(&m_resolutionViewportCalls, 0, sizeof(m_resolutionViewportCalls));
+					nvnPresentedTexture = false;
+				}
+				bool found = false;
+				int ratio = ((depth_width * 10) / (depth_height));
+				if (ratio < 12 || ratio > 18) {
+					found = true;
+				}
+				if (!found) {
+					for (size_t i = 0; i < 8; i++) {
+						if (depth_width == m_resolutionRenderCalls[i].width) {
+							m_resolutionRenderCalls[i].calls++;
+							break;
+						}
+						if (m_resolutionRenderCalls[i].width == 0) {
+							m_resolutionRenderCalls[i].width = depth_width;
+							m_resolutionRenderCalls[i].height = depth_height;
+							m_resolutionRenderCalls[i].calls = 1;
+							break;
+						}
 					}
 				}
 			}
 		}
+		return ((nvnCommandBufferSetRenderTargets_0)(Ptrs.nvnCommandBufferSetRenderTargets))(cmdBuf, numTextures, texture, textureView, depthTexture, depthView);
 	}
-	return ((nvnCommandBufferSetRenderTargets_0)(Ptrs.nvnCommandBufferSetRenderTargets))(cmdBuf, numTextures, texture, textureView, depthTexture, depthView);
-}
 
-uintptr_t nvnGetProcAddress (NVNDevice* nvnDevice, const char* nvnFunction) {
-	uintptr_t address = ((GetProcAddress)(Ptrs.nvnDeviceGetProcAddress))(nvnDevice, nvnFunction);
-	m_nvnDevice = nvnDevice;
-	if (!strcmp("nvnDeviceGetProcAddress", nvnFunction))
-		return Address.nvnGetProcAddress;
-	else if (!strcmp("nvnQueuePresentTexture", nvnFunction)) {
-		Ptrs.nvnQueuePresentTexture = address;
-		return Address.nvnQueuePresentTexture;
-	}
-	else if (!strcmp("nvnWindowAcquireTexture", nvnFunction)) {
-		Ptrs.nvnWindowAcquireTexture = address;
-		return Address.nvnWindowAcquireTexture;
-	}
-	else if (!strcmp("nvnWindowSetPresentInterval", nvnFunction)) {
-		Ptrs.nvnWindowSetPresentInterval = address;
-		return Address.nvnWindowSetPresentInterval;
-	}
-	else if (!strcmp("nvnWindowGetPresentInterval", nvnFunction)) {
-		Ptrs.nvnWindowGetPresentInterval = address;
+	//It's used to retrieve pointer to function asked in second argument
+	uintptr_t GetProcAddress0 (NVNDevice* nvnDevice, const char* nvnFunction) {
+		uintptr_t address = ((GetProcAddress)(Ptrs.nvnDeviceGetProcAddress))(nvnDevice, nvnFunction);
+		m_nvnDevice = nvnDevice;
+		if (!strcmp("nvnDeviceGetProcAddress", nvnFunction))
+			return (uintptr_t)&NVN::GetProcAddress0;
+		else if (!strcmp("nvnQueuePresentTexture", nvnFunction)) {
+			Ptrs.nvnQueuePresentTexture = address;
+			return (uintptr_t)&NVN::PresentTexture;
+		}
+		else if (!strcmp("nvnWindowAcquireTexture", nvnFunction)) {
+			Ptrs.nvnWindowAcquireTexture = address;
+			return (uintptr_t)&NVN::AcquireTexture;
+		}
+		else if (!strcmp("nvnWindowSetPresentInterval", nvnFunction)) {
+			Ptrs.nvnWindowSetPresentInterval = address;
+			return (uintptr_t)&NVN::SetPresentInterval;
+		}
+		else if (!strcmp("nvnWindowGetPresentInterval", nvnFunction)) {
+			Ptrs.nvnWindowGetPresentInterval = address;
+		}
+		else if (!strcmp("nvnWindowSetNumActiveTextures", nvnFunction)) {
+			Ptrs.nvnWindowSetNumActiveTextures = address;
+			return (uintptr_t)&NVN::WindowSetNumActiveTextures;
+		}
+		else if (!strcmp("nvnWindowBuilderSetTextures", nvnFunction)) {
+			Ptrs.nvnWindowBuilderSetTextures = address;
+			return (uintptr_t)&NVN::WindowBuilderSetTextures;
+		}
+		else if (!strcmp("nvnWindowInitialize", nvnFunction)) {
+			Ptrs.nvnWindowInitialize = address;
+			return (uintptr_t)&NVN::WindowInitialize;
+		}
+		else if (!strcmp("nvnSyncWait", nvnFunction)) {
+			Ptrs.nvnSyncWait = address;
+			return (uintptr_t)&NVN::SyncWait0;
+		}
+		else if (!strcmp("nvnCommandBufferSetRenderTargets", nvnFunction)) {
+			Ptrs.nvnCommandBufferSetRenderTargets = address;
+			return (uintptr_t)&NVN::CommandBufferSetRenderTargets;
+		}
+		else if (!strcmp("nvnCommandBufferSetViewport", nvnFunction)) {
+			Ptrs.nvnCommandBufferSetViewport = address;
+			return (uintptr_t)&NVN::CommandBufferSetViewport;
+		}
+		else if (!strcmp("nvnCommandBufferSetViewports", nvnFunction)) {
+			Ptrs.nvnCommandBufferSetViewports = address;
+			return (uintptr_t)&NVN::CommandBufferSetViewports;
+		}
+		else if (!strcmp("nvnTextureGetWidth", nvnFunction)) {
+			Ptrs.nvnTextureGetWidth = address;
+		}
+		else if (!strcmp("nvnTextureGetHeight", nvnFunction)) {
+			Ptrs.nvnTextureGetHeight = address;
+		}
+		else if (!strcmp("nvnTextureGetFormat", nvnFunction)) {
+			Ptrs.nvnTextureGetFormat = address;
+		}
 		return address;
 	}
-	else if (!strcmp("nvnWindowSetNumActiveTextures", nvnFunction)) {
-		Ptrs.nvnWindowSetNumActiveTextures = address;
-		return Address.nvnWindowSetNumActiveTextures;
-	}
-	else if (!strcmp("nvnWindowBuilderSetTextures", nvnFunction)) {
-		Ptrs.nvnWindowBuilderSetTextures = address;
-		return Address.nvnWindowBuilderSetTextures;
-	}
-	else if (!strcmp("nvnWindowInitialize", nvnFunction)) {
-		Ptrs.nvnWindowInitialize = address;
-		return Address.nvnWindowInitialize;
-	}
-	else if (!strcmp("nvnSyncWait", nvnFunction)) {
-		Ptrs.nvnSyncWait = address;
-		return Address.nvnSyncWait;
-	}
-	else if (!strcmp("nvnCommandBufferSetRenderTargets", nvnFunction)) {
-		Ptrs.nvnCommandBufferSetRenderTargets = address;
-		return Address.nvnCommandBufferSetRenderTargets;
-	}
-	else if (!strcmp("nvnCommandBufferSetViewport", nvnFunction)) {
-		Ptrs.nvnCommandBufferSetViewport = address;
-		return Address.nvnCommandBufferSetViewport;
-	}
-	else if (!strcmp("nvnCommandBufferSetViewports", nvnFunction)) {
-		Ptrs.nvnCommandBufferSetViewports = address;
-		return Address.nvnCommandBufferSetViewports;
-	}
-	else if (!strcmp("nvnTextureGetWidth", nvnFunction)) {
-		Ptrs.nvnTextureGetWidth = address;
-	}
-	else if (!strcmp("nvnTextureGetHeight", nvnFunction)) {
-		Ptrs.nvnTextureGetHeight = address;
-	}
-	else if (!strcmp("nvnTextureGetFormat", nvnFunction)) {
-		Ptrs.nvnTextureGetFormat = address;
-	}
-	return address;
-}
 
-uintptr_t nvnBootstrapLoader_1(const char* nvnName) {
-	if (strcmp(nvnName, "nvnDeviceGetProcAddress") == 0) {
-		(Shared -> API) = 1;
-		Ptrs.nvnDeviceGetProcAddress = ((nvnBootstrapLoader_0)(Address_weaks.nvnBootstrapLoader))("nvnDeviceGetProcAddress");
-		return Address.nvnGetProcAddress;
+	//It's the only exposed nvn function, used to retrieve only nvnDeviceGetProcAddress
+	uintptr_t BootstrapLoader_1(const char* nvnName) {
+		if (strcmp(nvnName, "nvnDeviceGetProcAddress") == 0) {
+			(Shared -> API) = 1;
+			Ptrs.nvnDeviceGetProcAddress = ((nvnBootstrapLoader_0)(Address_weaks.nvnBootstrapLoader))("nvnDeviceGetProcAddress");
+			return (uintptr_t)&NVN::GetProcAddress0;
+		}
+		uintptr_t ptrret = ((nvnBootstrapLoader_0)(Address_weaks.nvnBootstrapLoader))(nvnName);
+		return ptrret;
 	}
-	uintptr_t ptrret = ((nvnBootstrapLoader_0)(Address_weaks.nvnBootstrapLoader))(nvnName);
-	return ptrret;
 }
 
 extern "C" {
@@ -1096,10 +850,6 @@ extern "C" {
 			Shared = (NxFpsSharedBlock*)((uintptr_t)shmemGetAddr(_sharedmemory) + SharedMemoryOffset);
 			Shared -> MAGIC = 0x465053;
 			
-			Address.nvnGetProcAddress = (uintptr_t)&nvnGetProcAddress;
-			Address.nvnQueuePresentTexture = (uintptr_t)&nvnPresentTexture;
-			Address.nvnWindowAcquireTexture = (uintptr_t)&nvnAcquireTexture;
-			Address.nvnWindowInitialize = (uintptr_t)&nvnWindowInitialize;
 			Address_weaks.nvnBootstrapLoader = SaltySDCore_FindSymbolBuiltin("nvnBootstrapLoader");
 			Address_weaks.eglSwapBuffers = SaltySDCore_FindSymbolBuiltin("eglSwapBuffers");
 			Address_weaks.eglSwapInterval = SaltySDCore_FindSymbolBuiltin("eglSwapInterval");
@@ -1110,23 +860,13 @@ extern "C" {
 			Address_weaks.eglGetProcAddress = SaltySDCore_FindSymbolBuiltin("eglGetProcAddress");
 			Address_weaks.GetOperationMode = SaltySDCore_FindSymbolBuiltin("_ZN2nn2oe16GetOperationModeEv");
 			Address_weaks.vkGetInstanceProcAddr = SaltySDCore_FindSymbolBuiltin("vkGetInstanceProcAddr");
-			SaltySDCore_ReplaceImport("nvnBootstrapLoader", (void*)nvnBootstrapLoader_1);
-			SaltySDCore_ReplaceImport("eglSwapBuffers", (void*)eglSwap);
-			SaltySDCore_ReplaceImport("eglSwapInterval", (void*)eglInterval);
-			SaltySDCore_ReplaceImport("vkQueuePresentKHR", (void*)vulkanSwap);
-			SaltySDCore_ReplaceImport("_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR", (void*)vulkanSwap2);
-			SaltySDCore_ReplaceImport("eglGetProcAddress", (void*)eglGetProc);
-			SaltySDCore_ReplaceImport("vkGetInstanceProcAddr", (void*)vkGetInstanceProcAddr);
-			Address.nvnWindowSetPresentInterval = (uintptr_t)&nvnSetPresentInterval;
-			Address.nvnSyncWait = (uintptr_t)&nvnSyncWait0;
-			Address.nvnWindowBuilderSetTextures = (uintptr_t)&nvnWindowBuilderSetTextures;
-			Address.nvnWindowSetNumActiveTextures = (uintptr_t)&nvnWindowSetNumActiveTextures;
-			Address.eglGetProcAddress = (uintptr_t)&eglGetProc;
-			Address.eglSwapBuffers = (uintptr_t)&eglSwap;
-			Address.eglSwapInterval = (uintptr_t)&eglInterval;
-			Address.nvnCommandBufferSetRenderTargets = (uintptr_t)&nvnCommandBufferSetRenderTargets;
-			Address.nvnCommandBufferSetViewport = (uintptr_t)&nvnCommandBufferSetViewport;
-			Address.nvnCommandBufferSetViewports = (uintptr_t)&nvnCommandBufferSetViewports;
+			SaltySDCore_ReplaceImport("nvnBootstrapLoader", (void*)NVN::BootstrapLoader_1);
+			SaltySDCore_ReplaceImport("eglSwapBuffers", (void*)EGL::Swap);
+			SaltySDCore_ReplaceImport("eglSwapInterval", (void*)EGL::Interval);
+			SaltySDCore_ReplaceImport("vkQueuePresentKHR", (void*)vk::QueuePresent);
+			SaltySDCore_ReplaceImport("_ZN11NvSwapchain15QueuePresentKHREP9VkQueue_TPK16VkPresentInfoKHR", (void*)vk::nvSwapchain::QueuePresent);
+			SaltySDCore_ReplaceImport("eglGetProcAddress", (void*)EGL::GetProc);
+			SaltySDCore_ReplaceImport("vkGetInstanceProcAddr", (void*)vk::GetInstanceProcAddr);
 
 			uint64_t titleid = 0;
 			svcGetInfo(&titleid, InfoType_TitleId, CUR_PROCESS_HANDLE, 0);	

--- a/saltysd_proc/Makefile
+++ b/saltysd_proc/Makefile
@@ -39,7 +39,7 @@ EXEFS_SRC	:=	exefs_src
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
+ARCH	:=	-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -Os \
 			-ffast-math \

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -14,15 +14,53 @@
 #include "loadelf.h"
 #include "useful.h"
 #include "dmntcht.h"
+#include <math.h>
 
 #define MODULE_SALTYSD 420
+#define	NVDISP_GET_MODE 0x80380204
+#define	NVDISP_SET_MODE 0x40380205
+#define NVDISP_VALIDATE_MODE 0xC038020A
+#define NVDISP_PANEL_GET_VENDOR_ID 0xC003021A
+#define DSI_CLOCK_HZ 234000000llu
+
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
+
+struct resolutionCalls {
+	uint16_t width;
+	uint16_t height;
+	uint16_t calls;
+};
+
+struct NxFpsSharedBlock {
+	uint32_t MAGIC;
+	uint8_t FPS;
+	float FPSavg;
+	bool pluginActive;
+	uint8_t FPSlocked;
+	uint8_t FPSmode;
+	uint8_t ZeroSync;
+	uint8_t patchApplied;
+	uint8_t API;
+	uint32_t FPSticks[10];
+	uint8_t Buffers;
+	uint8_t SetBuffers;
+	uint8_t ActiveBuffers;
+	uint8_t SetActiveBuffers;
+	uint8_t displaySync;
+	struct resolutionCalls renderCalls[8];
+	struct resolutionCalls viewportCalls[8];
+	bool forceOriginalRefreshRate;
+} NX_PACKED;
+
+struct NxFpsSharedBlock* nx_fps = 0;
 
 u32 __nx_applet_type = AppletType_None;
 
 void serviceThread(void* buf);
 
 Handle saltyport, sdcard, injectserv;
-static char g_heap[0x70000];
+static char g_heap[0x80000];
 bool should_terminate = false;
 bool already_hijacking = false;
 DebugEventInfo eventinfo;
@@ -35,8 +73,24 @@ bool displaySync = false;
 uint8_t refreshRate = 0;
 s64 lastAppPID = -1;
 bool isOLED = false;
-bool isErista = false;
+bool isLite = false;
 bool cheatCheck = false;
+bool isDocked = false;
+bool dontForce60InDocked = false;
+bool matchLowestDocked = false;
+
+/// Edid2
+typedef struct {
+	SetSysEdid edid;
+	char reserved[0x100];
+} SetSysEdid2;
+
+Result setsysGetEdid2(Service* g_setsysSrv, SetSysEdid2 *out) {
+    return serviceDispatch(g_setsysSrv, 41,
+        .buffer_attrs = { SfBufferAttr_FixedSize | SfBufferAttr_HipcPointer | SfBufferAttr_Out },
+        .buffers = { { out, sizeof(*out) } },
+    );
+}
 
 void __libnx_initheap(void)
 {
@@ -49,20 +103,57 @@ void __libnx_initheap(void)
 
 void __appInit(void)
 {
-    
+    svcSleepThread(1*1000*1000*1000);
 }
 
 void __appExit(void)
 {
     already_hijacking = false;
-    fsdevUnmountAll();
-    fsExit();
+    fsdevUnmountAll_old();
     smExit();
+    setsysExit();
+}
+
+void ABORT_IF_FAILED(Result rc, uint8_t ID) {
+    if (R_FAILED(rc)) {
+        uint32_t* address = (uint32_t*)(0x7100000000 + ID);
+        *address = rc;
+    }
+}
+
+//Tweaks to nvInitialize so it will take less RAM
+#define NVDRV_TMEM_SIZE (8 * 0x1000)
+alignas(0x1000) char nvdrv_tmem_data[NVDRV_TMEM_SIZE];
+
+Result __nx_nv_create_tmem(TransferMemory *t, u32 *out_size, Permission perm) {
+    *out_size = NVDRV_TMEM_SIZE;
+    return tmemCreateFromMemory(t, nvdrv_tmem_data, NVDRV_TMEM_SIZE, perm);
 }
 
 u64 TIDnow;
 u64 PIDnow;
 u64 BIDnow;
+
+bool DockedModeRefreshRateAllowed[]         = { false,  //40Hz
+                                                false,  //45Hz
+                                                true,   //50Hz
+                                                false,  //55Hz
+                                                true};  //60Hz
+
+uint8_t DockedModeRefreshRateAllowedValues[] = { 40,
+                                                 45,
+                                                 50,
+                                                 55,
+                                                 60};
+
+static_assert(sizeof(DockedModeRefreshRateAllowedValues) == sizeof(DockedModeRefreshRateAllowed));
+
+struct MinMax {
+    u8 min;
+    u8 max;
+};
+
+struct MinMax HandheldModeRefreshRateAllowed = {40, 60};
 
 struct PLLD_BASE {
     unsigned int PLLD_DIVM: 8;
@@ -96,41 +187,284 @@ struct PLLD_MISC {
     unsigned int reserved: 2;
 };
 
-bool SetDisplayRefreshRate(uint32_t refreshRate) {
-    if (!clkVirtAddr)
-        return false;
-    if (refreshRate > 75 || refreshRate < 35 || refreshRate % 5 != 0)
+struct nvdcMode {
+    unsigned int hActive;
+    unsigned int vActive;
+    unsigned int hSyncWidth;
+    unsigned int vSyncWidth;
+    unsigned int hFrontPorch;
+    unsigned int vFrontPorch;
+    unsigned int hBackPorch;
+    unsigned int vBackPorch;
+    unsigned int hRefToSync; //always 1
+    unsigned int vRefToSync; //always 1
+    unsigned int pclkKHz;
+    unsigned int bitsPerPixel; //always 0
+    unsigned int vmode; //always 0
+};
+
+void setDefaultDockedSettings() {
+    for (size_t i = 0; i < sizeof(DockedModeRefreshRateAllowed); i++) {
+        if (DockedModeRefreshRateAllowedValues[i] == 50 || DockedModeRefreshRateAllowedValues[i] == 60) DockedModeRefreshRateAllowed[i] = true;
+        else DockedModeRefreshRateAllowed[i] = false;
+    }
+    dontForce60InDocked = false;
+    matchLowestDocked = false;
+}
+
+void LoadDockedModeAllowedSave() {
+    SetSysEdid2 edid2 = {0};
+    setDefaultDockedSettings();
+    if (R_FAILED(setsysGetEdid2(setsysGetServiceSession(), &edid2))) {
+        SaltySD_printf("SaltySD: Couldn't retrieve display EDID! Locking allowed refresh rates in docked mode to 50 and 60 Hz.\n");
+        return;
+    }
+    char path[128] = "";
+    snprintf(path, sizeof(path), "sdmc:/SaltySD/plugins/FPSLocker/ExtDisplays/%08X.dat", crc32Calculate(&edid2.edid, sizeof(edid2.edid)));
+    FILE* file = fopen(path, "rb");
+    if (file) {
+        u64 MAGIC = 0x00FFFFFFFFFFFF00;
+        u64 checkMAGIC = 0;
+        fread(&checkMAGIC, 8, 1, file);
+        if (checkMAGIC != MAGIC) {
+            fclose(file);
+            SaltySD_printf("SaltySD: File \"%s\" is invalid! Locking allowed refresh rates in docked mode to 50 and 60 Hz.\n", path);
+            return;
+        }
+
+        SaltySD_printf("SaltySD: File \"%s\" was loaded! Allowed refresh rates: 60", path);
+        fseek(file, 0x100, 0);
+        for (size_t i = 0; i < sizeof(DockedModeRefreshRateAllowed); i++) {
+            bool temp = false;
+            if (!fread(&temp, 1, 1, file))
+                break;
+            if (DockedModeRefreshRateAllowedValues[i] == 60)
+                continue;
+            DockedModeRefreshRateAllowed[i] = temp;
+            if (temp == true) {
+                SaltySD_printf(", %d", DockedModeRefreshRateAllowedValues[i]);
+            }
+        }
+        SaltySD_printf(".\n");
+        fseek(file, 0x180, 0);
+        uint8_t temp = 2;
+        fread(&temp, 1, 1, file);
+        if (temp > 1) SaltySD_printf("SaltySD: File \"%s\" has invalid dontForce60InDocked value. Setting it to false.\n", path);
+        else dontForce60InDocked = (bool)temp;
+        temp = 2;
+        fread(&temp, 1, 1, file);
+        if (temp > 1) SaltySD_printf("SaltySD: File \"%s\" has invalid matchLowestDocked value. Setting it to false.\n", path);
+        else matchLowestDocked = (bool)temp;
+        fclose(file);
+    }
+    else {
+        SaltySD_printf("SaltySD: File \"%s\" not found! Locking allowed refresh rates in docked mode to 50 and 60 Hz.\n", path);
+    }
+}
+
+bool canChangeRefreshRateDocked = false;
+
+bool SetDisplayRefreshRate(uint32_t new_refreshRate) {
+    if (!clkVirtAddr || !new_refreshRate)
         return false;
     struct PLLD_BASE base = {0};
     struct PLLD_MISC misc = {0};
     memcpy(&base, (void*)(clkVirtAddr + 0xD0), 4);
     memcpy(&misc, (void*)(clkVirtAddr + 0xDC), 4);
+    uint32_t value = ((base.PLLD_DIVN / base.PLLD_DIVM) * 10) / 4;
+    if (value == 0 || value == 80) { //We are in docked mode
+        if (isLite || !canChangeRefreshRateDocked)
+            return false;
+        uint32_t fd = 0;
+        if (R_FAILED(nvOpen(&fd, "/dev/nvdisp-disp1"))) {
+            return false;
+        }
+        struct nvdcMode DISPLAY_B = {0};
+        Result nvrc = nvIoctl(fd, NVDISP_GET_MODE, &DISPLAY_B);
+        if (R_FAILED(nvrc)) {
+            SaltySD_printf("SaltySD: NVDISP_GET_MODE failed! rc: 0x%x\n", nvrc);
+            nvClose(fd);
+            return false;
+        }
+        if (!DISPLAY_B.pclkKHz) {
+            nvClose(fd);
+            return false;
+        }
+        uint32_t h_total = DISPLAY_B.hActive + DISPLAY_B.hFrontPorch + DISPLAY_B.hSyncWidth + DISPLAY_B.hBackPorch;
+        uint32_t v_total = DISPLAY_B.vActive + DISPLAY_B.vFrontPorch + DISPLAY_B.vSyncWidth + DISPLAY_B.vBackPorch;
+        uint32_t refreshRateNow = ((DISPLAY_B.pclkKHz) * 1000 + 999) / (h_total * v_total);
+        int8_t itr = -1;
+        if ((60 == new_refreshRate) || (60 == (new_refreshRate * 2)) || (60 == (new_refreshRate * 3)) || (60 == (new_refreshRate * 4))) {
+            itr = 4;
+        }
+        if (itr == -1) for (size_t i = 0; i < sizeof(DockedModeRefreshRateAllowed); i++) {
+            if (DockedModeRefreshRateAllowed[i] != true)
+                continue;
+            uint8_t val = DockedModeRefreshRateAllowedValues[i];
+            if ((val == new_refreshRate) || (val == (new_refreshRate * 2)) || (val == (new_refreshRate * 3)) || (val == (new_refreshRate * 4))) {
+                itr = i;
+                break;
+            }
+        }
+        if (itr == -1) {
+            if (!matchLowestDocked)
+                itr = 4;
+            else for (size_t i = 0; i < sizeof(DockedModeRefreshRateAllowed); i++) {
+                if ((DockedModeRefreshRateAllowed[i] == true) && (new_refreshRate < DockedModeRefreshRateAllowedValues[i])) {
+                    itr = i;
+                    break;
+                }
+            }
+        }
+        bool increase = refreshRateNow < DockedModeRefreshRateAllowedValues[itr];
+        while(itr >= 0 && itr < sizeof(DockedModeRefreshRateAllowed) && DockedModeRefreshRateAllowed[itr] != true) {
+            if (!displaySync) {
+                if (increase) itr++;
+                else itr--;
+            }
+            else itr++;
+        }
+        if (refreshRateNow == DockedModeRefreshRateAllowedValues[itr]) {
+            if (nx_fps) nx_fps->displaySync = DockedModeRefreshRateAllowedValues[itr];
+            nvClose(fd);
+            return true;
+        }
+        
+        if (itr >= 0 && itr < sizeof(DockedModeRefreshRateAllowed)) {
+            uint32_t clock = ((h_total * v_total) * DockedModeRefreshRateAllowedValues[itr]) / 1000;
+            DISPLAY_B.pclkKHz = clock;
+            nvrc = nvIoctl(fd, NVDISP_VALIDATE_MODE, &DISPLAY_B);
+            if (R_SUCCEEDED(nvrc)) {
+                nvrc = nvIoctl(fd, NVDISP_SET_MODE, &DISPLAY_B);
+                if (R_FAILED(nvrc)) SaltySD_printf("SaltySD: NVDISP_SET_MODE failed! rc: 0x%x\n", nvrc);
+                else if (nx_fps) nx_fps->displaySync = DockedModeRefreshRateAllowedValues[itr];
+            }
+            else SaltySD_printf("SaltySD: NVDISP_VALIDATE_MODE failed! rc: 0x%x, pclkKHz: %d, Hz: %d\n", nvrc, clock, DockedModeRefreshRateAllowedValues[itr]);
+        }
+        nvClose(fd);
+        return true;
+
+    }
+    //We are in handheld mode
     
-    base.PLLD_DIVN = (4 * refreshRate) / 10;
+    if (new_refreshRate > HandheldModeRefreshRateAllowed.max) {
+        new_refreshRate = HandheldModeRefreshRateAllowed.max;
+    }
+    else if (new_refreshRate < HandheldModeRefreshRateAllowed.min) {
+        bool skip = false;
+        for (size_t i = 2; i <= 4; i++) {
+            if (new_refreshRate * i == 60) {
+                skip = true;
+                new_refreshRate = 60;
+                break;
+            }
+        }
+        if (!skip) for (size_t i = 2; i <= 4; i++) {
+            if (((new_refreshRate * i) >= HandheldModeRefreshRateAllowed.min) && ((new_refreshRate * i) <= HandheldModeRefreshRateAllowed.max)) {
+                skip = true;
+                new_refreshRate *= i;
+                break;
+            }
+        }
+        if (!skip) new_refreshRate = 60;
+    }
+    uint32_t pixelClock = (9375 * ((4096 * ((2 * base.PLLD_DIVN) + 1)) + misc.PLLD_SDM_DIN)) / (8 * base.PLLD_DIVM);
+    uint16_t refreshRateNow = pixelClock / (DSI_CLOCK_HZ / 60);
+
+    if (refreshRateNow == new_refreshRate) {
+        if (nx_fps) nx_fps->displaySync = new_refreshRate;
+        return true;
+    }
+
+    uint8_t base_refreshRate = new_refreshRate - (new_refreshRate % 5);
+
+    base.PLLD_DIVN = (4 * base_refreshRate) / 10;
     base.PLLD_DIVM = 1;
 
-    int16_t Step_5Hz = 256;
-    int16_t default_SDM_DIN = -1024;
-    int8_t steps = ((int32_t)refreshRate - 60) / 5;
-    
-    misc.PLLD_SDM_DIN = default_SDM_DIN + (Step_5Hz * steps);
+    uint64_t expected_pixel_clock = (DSI_CLOCK_HZ * new_refreshRate) / 60;
+
+    misc.PLLD_SDM_DIN = ((8 * base.PLLD_DIVM * expected_pixel_clock) / 9375) - (4096 * ((2 * base.PLLD_DIVN)+1));
 
     memcpy((void*)(clkVirtAddr + 0xD0), &base, 4);
     memcpy((void*)(clkVirtAddr + 0xDC), &misc, 4);
+    if (nx_fps) nx_fps->displaySync = new_refreshRate;
     return true;
 }
 
-bool GetDisplayRefreshRate(uint32_t* refreshRate) {
+bool GetDisplayRefreshRate(uint32_t* out_refreshRate, bool internal) {
     if (!clkVirtAddr)
         return false;
-    struct PLLD_BASE temp = {0};
-    uint32_t value = *(uint32_t*)(clkVirtAddr + 0xD0);
-    memcpy(&temp, &value, 4);
-    value = ((temp.PLLD_DIVN / temp.PLLD_DIVM) * 10) / 4;
-    if (value == 0)
-        value = 60;
-    *refreshRate = value;
     uintptr_t sh_addr = (uintptr_t)shmemGetAddr(&_sharedMemory);
+    if (!internal) {
+        // We are using this trick because using nvOpen severes connection 
+        // with whatever is actually connected to this sysmodule
+        if (sh_addr) {
+            *out_refreshRate = *(uint8_t*)(sh_addr + 1);
+            return true;
+        }
+        else return false;
+    }
+    struct PLLD_BASE temp = {0};
+    struct PLLD_MISC misc = {0};
+    memcpy(&temp, (void*)(clkVirtAddr + 0xD0), 4);
+    memcpy(&misc, (void*)(clkVirtAddr + 0xDC), 4);
+    uint32_t value = ((temp.PLLD_DIVN / temp.PLLD_DIVM) * 10) / 4;
+    static uint64_t tick = 0;
+    if (value == 0 || value == 80) { //We are in docked mode
+        if (isLite)
+            return false;
+        isDocked = true;
+        //We must add delay for changing refresh rate when it was just put into dock to avoid doing calculation on default values instead of adjusted ones
+        //From my tests 1 second is enough
+        if (!canChangeRefreshRateDocked) {
+            if (!tick) {
+                tick = svcGetSystemTick();
+                return false;
+            }
+            if (svcGetSystemTick() - tick < 19200000) {
+                return false;
+            }
+            else {
+                tick = 0;
+                LoadDockedModeAllowedSave();
+                canChangeRefreshRateDocked = true;
+            }
+        }
+        uint32_t fd = 0;
+        if (R_SUCCEEDED(nvOpen(&fd, "/dev/nvdisp-disp1"))) {
+            struct nvdcMode DISPLAY_B = {0};
+            if (R_SUCCEEDED(nvIoctl(fd, NVDISP_GET_MODE, &DISPLAY_B))) {
+                if (!DISPLAY_B.pclkKHz) {
+                    nvClose(fd);
+                    return false;
+                }
+                uint32_t h_total = DISPLAY_B.hActive + DISPLAY_B.hFrontPorch + DISPLAY_B.hSyncWidth + DISPLAY_B.hBackPorch;
+                uint32_t v_total = DISPLAY_B.vActive + DISPLAY_B.vFrontPorch + DISPLAY_B.vSyncWidth + DISPLAY_B.vBackPorch;
+                uint32_t pixelClock = DISPLAY_B.pclkKHz * 1000 + 999;
+                value = pixelClock / (h_total * v_total);
+            }
+            else value = 60;
+            nvClose(fd);
+        }
+        else value = 60;
+    }
+    else {
+        tick = 0;
+        isDocked = false;
+        canChangeRefreshRateDocked = false;
+        //We are in handheld mode
+        /*
+            Official formula:
+            Fvco = Fref / DIVM * (DIVN + 0.5 + (SDM_DIN / 8192))
+            Fref = CNTFRQ_EL0 / 2
+            Defaults: DIVM = 1, DIVN = 24, SDM_DIN = -1024
+
+            My math formula allows avoiding decimals whenever possible
+        */
+        uint32_t pixelClock = (9375 * ((4096 * ((2 * temp.PLLD_DIVN) + 1)) + misc.PLLD_SDM_DIN)) / (8 * temp.PLLD_DIVM);
+        value = pixelClock / (DSI_CLOCK_HZ / 60);
+    }
+    *out_refreshRate = value;
     if (sh_addr) 
         *(uint8_t*)(sh_addr + 1) = (uint8_t)value;
     return true;
@@ -748,9 +1082,9 @@ Result handleServiceCmd(int cmd)
         raw = ipcPrepareHeader(&c, sizeof(*raw));
 
         raw->magic = SFCO_MAGIC;
-        uint32_t refreshRate = 0;
-        raw->result = !GetDisplayRefreshRate(&refreshRate);
-        raw->refreshRate = refreshRate;
+        uint32_t temp_refreshRate = 0;
+        raw->result = !GetDisplayRefreshRate(&temp_refreshRate, false);
+        raw->refreshRate = temp_refreshRate;
 
         return 0;
     }
@@ -768,17 +1102,12 @@ Result handleServiceCmd(int cmd)
 
         u64 refreshRate_temp = resp -> refreshRate;
 
-        if (refreshRate_temp > 79 || refreshRate_temp < 31) {
-            SaltySD_printf("SaltySD: cmd 11 handler -> %d, invalid value. Setting 60...\n", refreshRate_temp);
-            refreshRate = 60;
-        }
-        else {
-            SaltySD_printf("SaltySD: cmd 11 handler -> %d\n", refreshRate_temp);
+        if (SetDisplayRefreshRate(refreshRate_temp)) {
             refreshRate = refreshRate_temp;
-        }
-        if (SetDisplayRefreshRate(refreshRate)) 
             ret = 0;
+        }
         else ret = 0x1234;
+        SaltySD_printf("SaltySD: cmd 11 handler -> %d\n", refreshRate_temp);
     }
     else if (cmd == 12) // SetDisplaySync
     {
@@ -792,20 +1121,81 @@ Result handleServiceCmd(int cmd)
             u64 reserved;
         } *resp = r.Raw;
 
-        if (!isOLED) displaySync = (bool)(resp -> value);
-        if (!isOLED && displaySync) {
+        displaySync = (bool)(resp -> value);
+        if (displaySync) {
             FILE* file = fopen("sdmc:/SaltySD/flags/displaysync.flag", "wb");
             fclose(file);
             SaltySD_printf("SaltySD: cmd 12 handler -> %d\n", displaySync);
-        }
-        else if (isOLED) {
-            SaltySD_printf("SaltySD: cmd 12 handler -> %d. Detected OLED model, ignoring...\n", displaySync);
-            remove("sdmc:/SaltySD/flags/displaysync.flag");
         }
         else {
             remove("sdmc:/SaltySD/flags/displaysync.flag");
             SaltySD_printf("SaltySD: cmd 12 handler -> %d\n", displaySync);
         }
+
+        ret = 0;
+    }
+    else if (cmd == 13) // SetAllowedDockedRefreshRates
+    {
+        IpcParsedCommand r = {0};
+        ipcParse(&r);
+
+        struct {
+            u64 magic;
+            u64 cmd_id;
+            u32 refreshRate;
+            u32 reserved[3];
+        } *resp = r.Raw;
+
+        struct {
+            unsigned int Hz_40: 1;
+            unsigned int Hz_45: 1;
+            unsigned int Hz_50: 1;
+            unsigned int Hz_55: 1;
+            unsigned int Hz_60: 1;
+            unsigned int reserved: 27;
+        } DockedRefreshRates;
+
+        memcpy(&DockedRefreshRates, &(resp -> refreshRate), 4);
+        DockedModeRefreshRateAllowed[0] = DockedRefreshRates.Hz_40;
+        DockedModeRefreshRateAllowed[1] = DockedRefreshRates.Hz_45;
+        DockedModeRefreshRateAllowed[2] = DockedRefreshRates.Hz_50;
+        DockedModeRefreshRateAllowed[3] = DockedRefreshRates.Hz_55;
+        DockedModeRefreshRateAllowed[4] = true;
+        SaltySD_printf("SaltySD: cmd 13 handler\n");
+
+        ret = 0;
+    }
+    else if (cmd == 14) // SetDontForce60InDocked
+    {
+        IpcParsedCommand r = {0};
+        ipcParse(&r);
+
+        struct {
+            u64 magic;
+            u64 cmd_id;
+            u64 force;
+            u64 reserved;
+        } *resp = r.Raw;
+
+        dontForce60InDocked = (bool)(resp -> force);
+        SaltySD_printf("SaltySD: cmd 14 handler\n");
+
+        ret = 0;
+    }
+    else if (cmd == 15) // SetMatchLowestRR
+    {
+        IpcParsedCommand r = {0};
+        ipcParse(&r);
+
+        struct {
+            u64 magic;
+            u64 cmd_id;
+            u64 force;
+            u64 reserved;
+        } *resp = r.Raw;
+
+        matchLowestDocked = (bool)(resp -> force);
+        SaltySD_printf("SaltySD: cmd 15 handler\n");
 
         ret = 0;
     }
@@ -889,41 +1279,59 @@ void serviceThread(void* buf)
 
 int main(int argc, char *argv[])
 {
-    
-    svcSleepThread(1*1000*1000*1000);
-    smInitialize_old();
+    ABORT_IF_FAILED(smInitialize_old(), 0);
     Service_old toget;
-    smGetService_old(&toget, "fsp-srv");
-    fsp_init(toget);
-    fsp_getSdCard(toget, &sdcard);
+    ABORT_IF_FAILED(smGetService_old(&toget, "fsp-srv"), 1);
+    ABORT_IF_FAILED(fsp_init(toget), 2);
+    ABORT_IF_FAILED(fsp_getSdCard(toget, &sdcard), 3);
     FsFileSystem_old sdcardfs;
     sdcardfs.s.handle = sdcard;
-    fsdevMountDevice_old("sdmc", sdcardfs);
-    //serviceClose_old(&toget);
+    if (fsdevMountDevice_old("sdmc", sdcardfs) == -1) {
+        ABORT_IF_FAILED(0xDEADBEEF, 4);
+    }
+    serviceClose_old(&toget);
     smExit_old();
-    smInitialize();
     SaltySD_printf("SaltySD: got SD card.\n");
+
+    ABORT_IF_FAILED(smInitialize(), 5);
+    ABORT_IF_FAILED(setsysInitialize(), 10);
+
+    SetSysProductModel model;
+    if (R_SUCCEEDED(setsysGetProductModel(&model))) {
+        if (model == SetSysProductModel_Aula) {
+            SaltySD_printf("SaltySD: Detected OLED model. Display Sync is not available in handheld mode.\n");
+            isOLED = true;
+        }
+        else if (model == SetSysProductModel_Hoag) {
+            isLite = true;
+            SaltySD_printf("SaltySD: Detected Lite model. Docked refresh rate will be blocked.\n");
+        }
+    }
+
+    if (!isLite) {
+        ABORT_IF_FAILED(nvInitialize(), 6);
+        struct {
+            char reserved[3];
+        } pvi;
+        
+        u32 fd_temp;
+        if (R_SUCCEEDED(nvOpen(&fd_temp, "/dev/nvdisp-disp0"))) {
+            nvIoctl(fd_temp, NVDISP_PANEL_GET_VENDOR_ID, &pvi);
+            nvClose(fd_temp);
+            FILE* file = fopen("sdmc:/internal.dat", "wb");
+            fwrite(&pvi, 3, 1, file);
+            fclose(file);
+        }
+    }
     
-    ldrDmntInitialize();
+    ABORT_IF_FAILED(ldrDmntInitialize(), 7);
     Service* ldrDmntSrv = ldrDmntGetServiceSession();
     Service ldrDmntClone;
     serviceClone(ldrDmntSrv, &ldrDmntClone);
     serviceClose(ldrDmntSrv);
     memcpy(ldrDmntSrv, &ldrDmntClone, sizeof(Service));
 
-    setsysInitialize();
-    SetSysProductModel model;
-    if (R_SUCCEEDED(setsysGetProductModel(&model))) {
-        if (model == SetSysProductModel_Aula) {
-            SaltySD_printf("SaltySD: Detected OLED model. Display Sync is not available.\n");
-            isOLED = true;
-            remove("sdmc:/SaltySD/flags/displaysync.flag");
-        }
-        else if (model == SetSysProductModel_Nx) {
-            isErista = true;
-        }
-    }
-    setsysExit();
+
     FILE* file = fopen("sdmc:/SaltySD/flags/displaysync.flag", "rb");
     if (file) {
         fclose(file);
@@ -960,13 +1368,13 @@ int main(int argc, char *argv[])
         }
         
         if (lastAppPID != -1) {
-            static bool* force60Hz = 0;
-            if (!force60Hz)  {
+            if (!nx_fps)  {
                 uintptr_t sharedAddress = (uintptr_t)shmemGetAddr(&_sharedMemory);
                 if (sharedAddress) {
                     ptrdiff_t offset = searchNxFpsSharedMemoryBlock(sharedAddress);
-                    if (offset != -1)
-                        force60Hz = (bool*)(sharedAddress + offset + 0x9C);
+                    if (offset != -1) {
+                        nx_fps = (struct NxFpsSharedBlock*)(sharedAddress + offset);
+                    }
                 }
             }
             if (!cheatCheck) {
@@ -981,9 +1389,10 @@ int main(int argc, char *argv[])
                         svcCloseHandle(debug_handle);
                         if (thread_count > 1) {
                             cheatCheck = true;
-                            dmntchtInitialize();
-                            dmntchtForceOpenCheatProcess();
-                            dmntchtExit();
+                            if (R_SUCCEEDED(dmntchtInitialize())) {
+                                dmntchtForceOpenCheatProcess();
+                                dmntchtExit();
+                            }
                         }
                     }
                     else cheatCheck = true;
@@ -1000,20 +1409,20 @@ int main(int argc, char *argv[])
             }
             if (!found) {
                 lastAppPID = -1;
-                force60Hz = 0;
+                nx_fps = 0;
                 cheatCheck = false;
-                if (displaySync && !isOLED) {
+                if (displaySync) {
                     uint32_t temp_refreshRate = 0;
-                    if (GetDisplayRefreshRate(&temp_refreshRate) && temp_refreshRate != 60)
+                    if (GetDisplayRefreshRate(&temp_refreshRate, true) && temp_refreshRate != 60)
                         SetDisplayRefreshRate(60);
                     refreshRate = 0;
                 }
             }
-            else if (displaySync && !isOLED) {
+            else if (displaySync && (!isOLED || isDocked)) {
                 uint32_t temp_refreshRate = 0;
-                GetDisplayRefreshRate(&temp_refreshRate);
+                GetDisplayRefreshRate(&temp_refreshRate, true);
                 uint32_t check_refresh_rate = refreshRate;
-                if (force60Hz && *force60Hz) {
+                if (nx_fps && nx_fps->forceOriginalRefreshRate && (!isDocked || (isDocked && !dontForce60InDocked))) {
                     check_refresh_rate = 60;
                 }
                 if (temp_refreshRate != check_refresh_rate)
@@ -1021,7 +1430,7 @@ int main(int argc, char *argv[])
             }
         }
         uint32_t temp = 0;
-        GetDisplayRefreshRate(&temp);
+        GetDisplayRefreshRate(&temp, true);
 
         // Detected new PID
         if (max != old_max && max > 0x80)

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -599,12 +599,12 @@ void hijack_pid(u64 pid)
     Handle debug;
     
     FILE* disabled = fopen("sdmc:/SaltySD/flags/disable.flag", "r");
-    u8 disable = 1;
     
-    if (disabled == NULL) {
-        disable = 0;
+    if (disabled) {
+        fclose(disabled);
+        SaltySD_printf("SaltySD: Detected disable.flag, aborting bootstrap...\n");
+        return;
     }
-    else fclose(disabled);
     
     if (already_hijacking)
     {
@@ -645,10 +645,6 @@ void hijack_pid(u64 pid)
 
         if (eventinfo.type == DebugEvent_AttachProcess)
         {
-            if (disable == 1) {
-                SaltySD_printf("SaltySD: Detected disable.flag, aborting bootstrap...\n");
-                goto abort_bootstrap;
-            }
 
             if (eventinfo.tid <= 0x010000000000FFFF)
             {
@@ -751,14 +747,12 @@ void hijack_pid(u64 pid)
     }
     else {
         already_hijacking = false;
-        disable = 0;
     }
 
     return;
 
 abort_bootstrap:
     if (check) renameCheatsFolder();
-    disable = 0;
                 
     already_hijacking = false;
     svcCloseHandle(debug);

--- a/saltysd_proc/source/main.c
+++ b/saltysd_proc/source/main.c
@@ -20,7 +20,6 @@
 #define	NVDISP_GET_MODE 0x80380204
 #define	NVDISP_SET_MODE 0x40380205
 #define NVDISP_VALIDATE_MODE 0xC038020A
-#define NVDISP_PANEL_GET_VENDOR_ID 0xC003021A
 #define DSI_CLOCK_HZ 234000000llu
 
 #define MIN(a,b) (((a)<(b))?(a):(b))
@@ -1310,18 +1309,6 @@ int main(int argc, char *argv[])
 
     if (!isLite) {
         ABORT_IF_FAILED(nvInitialize(), 6);
-        struct {
-            char reserved[3];
-        } pvi;
-        
-        u32 fd_temp;
-        if (R_SUCCEEDED(nvOpen(&fd_temp, "/dev/nvdisp-disp0"))) {
-            nvIoctl(fd_temp, NVDISP_PANEL_GET_VENDOR_ID, &pvi);
-            nvClose(fd_temp);
-            FILE* file = fopen("sdmc:/internal.dat", "wb");
-            fwrite(&pvi, 3, 1, file);
-            fclose(file);
-        }
     }
     
     ABORT_IF_FAILED(ldrDmntInitialize(), 7);


### PR DESCRIPTION
Among other changes:
- Sysmodule now supports newest libnx
- Core is now completely independent from new libnx versions
- Math formula for changing refresh rate in handheld mode was drastically improved
- In NX-FPS now various functions related to pushing frames to display share common function for counting FPS
- Refresh rate is written to NX-FPS -> displaySync pointer whenever game runs.
- Now disabling SaltyNX in SaltyNX-Tool won't cause issues with dmnt.gen2 when attaching with `monitor wait application`