### PR TITLE
Add 'Hollow Knight: Silksong' to exceptions

### DIFF
--- a/exceptions.txt
+++ b/exceptions.txt
@@ -58,3 +58,7 @@ X0100423009358000
 ;Splatoon 3
 ;10.0.0 upwards crashes after online match
 X0100C2500FC20000
+
+;Hollow Knight: Silksong
+;Crash on boot
+X010013C00E930000


### PR DESCRIPTION
Hollow Knight: Silksong (010013C00E930000)

Issue:
- Game crashes at startup when SaltyNX is injected.

Fix:  
- Added Title ID to exceptions list.